### PR TITLE
Fix the ios UX rendering issue. Minor ui changes in event day page.

### DIFF
--- a/MySalesTracker.Application/Interfaces/IEventRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IEventRepository.cs
@@ -4,11 +4,11 @@ namespace MySalesTracker.Application.Interfaces;
 
 public interface IEventRepository
 {
-    Task<List<(string Name, DateOnly StartDate, DateOnly EndDate)>> GetExistingEventsByYear(int year, CancellationToken ct);
-    Task<List<Event>> GetAllEvents(CancellationToken ct);
-    Task<Event> CreateEvent(Event evt, CancellationToken ct);
-    Task<EventDay?> GetEventDayById(int id, CancellationToken ct);
-    Task<Event?> GetEventWithAllData(int eventId, CancellationToken ct);
+    Task<List<(string Name, DateOnly StartDate, DateOnly EndDate)>> GetExistingEventsByYearAsync(int year, CancellationToken ct);
+    Task<List<Event>> GetAllEventsAsync(CancellationToken ct);
+    Task<Event> CreateEventAsync(Event evt, CancellationToken ct);
+    Task<EventDay?> GetEventDayByIdAsync(int id, CancellationToken ct);
+    Task<Event?> GetEventWithAllDataAsync(int eventId, CancellationToken ct);
 
-    Task<EventDay?> UpdateStartingPettyCash(int eventDayId, decimal? amount, CancellationToken ct);
+    Task<EventDay?> UpdateStartingPettyCashAsync(int eventDayId, decimal? amount, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
@@ -4,6 +4,6 @@ using MySalesTracker.Domain.Models;
 namespace MySalesTracker.Application.Interfaces;
 public interface IPriceRuleRepository
 {
-    Task<PriceRule?> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct);
-    Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct);
+    Task<PriceRule?> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct);
+    Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
@@ -5,4 +5,5 @@ namespace MySalesTracker.Application.Interfaces;
 public interface IPriceRuleRepository
 {
     Task<PriceRule?> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct);
+    Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct);
 }

--- a/MySalesTracker.Application/Interfaces/IProductRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IProductRepository.cs
@@ -3,7 +3,7 @@ using MySalesTracker.Domain.Entities;
 namespace MySalesTracker.Application.Interfaces;
 public interface IProductRepository
 {
-    Task<List<Product>> GetActiveProducts(CancellationToken ct);
+    Task<List<Product>> GetActiveProductsAsync(CancellationToken ct);
 
-    Task<List<PriceRule>> GetPriceRulesForProduct(int productId, CancellationToken ct);
+    Task<List<PriceRule>> GetPriceRulesForProductAsync(int productId, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Services/EventService.cs
+++ b/MySalesTracker.Application/Services/EventService.cs
@@ -19,12 +19,12 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     /// where either the start date or end date falls within the specified year.
     /// Returns an empty list if no events match the criteria.
     /// </returns>
-    public async Task<List<(string, DateOnly, DateOnly)>> GetExistingEventsByYear(DateOnly year, CancellationToken cancellationToken = default)
+    public async Task<List<(string, DateOnly, DateOnly)>> GetExistingEventsByYearAsync(DateOnly year, CancellationToken cancellationToken = default)
     {
         //TODO: ⬆️ Consider Task<SomeModel> instead of list of tuples for better clarity.
         try
         {
-            return await eventRepository.GetExistingEventsByYear(year.Year, cancellationToken);
+            return await eventRepository.GetExistingEventsByYearAsync(year.Year, cancellationToken);
         }
         catch (Exception ex)
         {
@@ -46,7 +46,7 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     {
         try
         {
-            return await eventRepository.GetAllEvents(ct);
+            return await eventRepository.GetAllEventsAsync(ct);
         }
         catch (Exception ex)
         {
@@ -73,7 +73,7 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     {
         try
         {
-            var existingEvents = await GetExistingEventsByYear(startDate, ct);
+            var existingEvents = await GetExistingEventsByYearAsync(startDate, ct);
 
             var validation = EventValidations.ValidateCreateEvent(name, startDate, endDate, existingEvents);
             if (!validation.IsValid)
@@ -91,7 +91,7 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
                 evt.Days.Add(new EventDay { Date = date });
             }
 
-            var savedEvent = await eventRepository.CreateEvent(evt, ct);
+            var savedEvent = await eventRepository.CreateEventAsync(evt, ct);
 
             logger.LogInformation("Successfully created event {EventId} with {DayCount} days", savedEvent.EventId, savedEvent.Days.Count);
             return ServiceResult<Event>.SuccessResult(savedEvent);
@@ -116,7 +116,7 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     {
         try
         {
-            var evtDay = await eventRepository.GetEventDayById(eventDayId, ct);
+            var evtDay = await eventRepository.GetEventDayByIdAsync(eventDayId, ct);
 
             if (evtDay is null)
             {
@@ -146,7 +146,7 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     {
         try
         {
-            var evt = await eventRepository.GetEventWithAllData(eventId, ct);
+            var evt = await eventRepository.GetEventWithAllDataAsync(eventId, ct);
 
             if (evt is null)
             {
@@ -239,11 +239,11 @@ public sealed class EventService(IEventRepository eventRepository, ILogger<Event
     /// A <see cref="ServiceResult{EventDay}"/> containing the updated <see cref="EventDay"/>
     /// when successful, otherwise a failure result with an error message.
     /// </returns>
-    public async Task<ServiceResult<EventDay>> UpdateStartingPettyCash(int eventDayId, decimal? amount, CancellationToken ct = default)
+    public async Task<ServiceResult<EventDay>> UpdateStartingPettyCashAsync(int eventDayId, decimal? amount, CancellationToken ct = default)
     {
         try
         {
-            var evtDay = await eventRepository.UpdateStartingPettyCash(eventDayId, amount, ct);
+            var evtDay = await eventRepository.UpdateStartingPettyCashAsync(eventDayId, amount, ct);
 
             if (evtDay is null)
             {

--- a/MySalesTracker.Application/Services/PriceRuleService.cs
+++ b/MySalesTracker.Application/Services/PriceRuleService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using MySalesTracker.Application.Interfaces;
+using MySalesTracker.Domain.Entities;
 using MySalesTracker.Domain.Models;
 
 namespace MySalesTracker.Application.Services;
@@ -19,7 +20,7 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
     /// Returns (1, null) if no matching rule is found, ensuring safe fallback behavior.
     /// The rule is selected based on effective date range and sorted by EffectiveFrom descending, then SortOrder ascending.
     /// </returns>
-    public async Task<UnitsPerSale> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct = default)
+    public async Task<UnitsPerSale> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct = default)
     {
         try
         {
@@ -39,6 +40,19 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
         {
             logger.LogError(ex, "Failed to get units for Product {ProductId}, Price {Price}, Date {Date}", productId, price, onDate);
             throw;
+        }
+    }
+
+    public async Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct = default)
+    {
+        try
+        {
+            return await priceRuleRepository.GetAllPriceRules(ct);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to get all price rules.");
+            return [];
         }
     }
 }

--- a/MySalesTracker.Application/Services/PriceRuleService.cs
+++ b/MySalesTracker.Application/Services/PriceRuleService.cs
@@ -20,11 +20,11 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
     /// Returns (1, null) if no matching rule is found, ensuring safe fallback behavior.
     /// The rule is selected based on effective date range and sorted by EffectiveFrom descending, then SortOrder ascending.
     /// </returns>
-    public async Task<UnitsPerSale> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct = default)
+    public async Task<UnitsPerSale> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct = default)
     {
         try
         {
-            var priceRule = await priceRuleRepository.GetUnitsForProduct(productId, price, onDate, ct);
+            var priceRule = await priceRuleRepository.GetUnitsForProductAsync(productId, price, onDate, ct);
 
             if (priceRule is null)
             {
@@ -43,11 +43,19 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
         }
     }
 
-    public async Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct = default)
+
+    /// <summary>
+    /// Retrieves all price rules from the database.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A list of all <see cref="PriceRule"/> entities. Returns an empty list if an error occurs.
+    /// </returns>
+    public async Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct = default)
     {
         try
         {
-            return await priceRuleRepository.GetAllPriceRules(ct);
+            return await priceRuleRepository.GetAllPriceRulesAsync(onDate, ct);
         }
         catch (Exception ex)
         {

--- a/MySalesTracker.Application/Services/ProductService.cs
+++ b/MySalesTracker.Application/Services/ProductService.cs
@@ -18,7 +18,7 @@ public sealed class ProductService(IProductRepository productRepository, ILogger
     {
         try
         {
-            return await productRepository.GetActiveProducts(ct);
+            return await productRepository.GetActiveProductsAsync(ct);
         }
         catch (Exception ex)
         {
@@ -41,7 +41,7 @@ public sealed class ProductService(IProductRepository productRepository, ILogger
     {
         try
         {
-            return await productRepository.GetPriceRulesForProduct(productId, ct);
+            return await productRepository.GetPriceRulesForProductAsync(productId, ct);
         }
         catch (Exception ex)
         {

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/EventRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/EventRepository.cs
@@ -8,7 +8,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;
 
-    public async Task<List<(string Name, DateOnly StartDate, DateOnly EndDate)>> GetExistingEventsByYear(int year, CancellationToken ct)
+    public async Task<List<(string Name, DateOnly StartDate, DateOnly EndDate)>> GetExistingEventsByYearAsync(int year, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -20,7 +20,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
         return [.. events.Select(e => (e.Name, e.StartDate, e.EndDate))];
     }
 
-    public async Task<Event> CreateEvent(Event evt, CancellationToken ct)
+    public async Task<Event> CreateEventAsync(Event evt, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -30,7 +30,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
         return evt;
     }
 
-    public async Task<List<Event>> GetAllEvents(CancellationToken ct)
+    public async Task<List<Event>> GetAllEventsAsync(CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -40,7 +40,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
             .ToListAsync(ct);
     }
 
-    public async Task<EventDay?> GetEventDayById(int id, CancellationToken ct)
+    public async Task<EventDay?> GetEventDayByIdAsync(int id, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -51,7 +51,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
         return evtDay;
     }
 
-    public async Task<Event?> GetEventWithAllData(int eventId, CancellationToken ct)
+    public async Task<Event?> GetEventWithAllDataAsync(int eventId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -66,7 +66,7 @@ internal class EventRepository(IDbContextFactory<AppDbContext> contextFactory) :
             .FirstOrDefaultAsync(e => e.EventId == eventId, ct);
     }
 
-    public async Task<EventDay?> UpdateStartingPettyCash(int eventDayId, decimal? amount, CancellationToken ct)
+    public async Task<EventDay?> UpdateStartingPettyCashAsync(int eventDayId, decimal? amount, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
@@ -7,6 +7,13 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;
 
+    public async Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        return await context.PriceRules.ToListAsync(ct);
+    }
+
     public async Task<PriceRule?> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
@@ -7,14 +7,16 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;
 
-    public async Task<List<PriceRule>> GetAllPriceRules(CancellationToken ct)
+    public async Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
-        return await context.PriceRules.ToListAsync(ct);
+        return await context.PriceRules
+            .Where (r => r.EffectiveFrom <= onDate && (r.EffectiveTo == null || r.EffectiveTo >= onDate))
+            .ToListAsync(ct);
     }
 
-    public async Task<PriceRule?> GetUnitsForProduct(int productId, decimal price, DateOnly onDate, CancellationToken ct)
+    public async Task<PriceRule?> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -1,9 +1,9 @@
-using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using MySalesTracker.Application.Interfaces;
 using MySalesTracker.Domain.Entities;
 
 namespace MySalesTracker.Infrastructure.Persistence.Repositories;
+
 internal class ProductRepository(IDbContextFactory<AppDbContext> contextFactory) : IProductRepository
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -8,7 +8,7 @@ internal class ProductRepository(IDbContextFactory<AppDbContext> contextFactory)
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;
 
-    public async Task<List<Product>> GetActiveProducts(CancellationToken ct)
+    public async Task<List<Product>> GetActiveProductsAsync(CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
@@ -18,7 +18,7 @@ internal class ProductRepository(IDbContextFactory<AppDbContext> contextFactory)
                 .ToListAsync(ct);
     }
 
-    public async Task<List<PriceRule>> GetPriceRulesForProduct(int productId, CancellationToken ct)
+    public async Task<List<PriceRule>> GetPriceRulesForProductAsync(int productId, CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 

--- a/MySalesTracker.Web/Components/Pages/DailyReport.razor
+++ b/MySalesTracker.Web/Components/Pages/DailyReport.razor
@@ -107,7 +107,7 @@ else
         </table>
 
         <div class="mt-3">
-            <button class="btn btn-primary" @onclick="SavePayments" disabled="@(isSaving || summary is null)">
+            <button class="btn btn-primary" @onclick="SavePayments" disabled="@DisableSaveButton">
                 @(isSaving ? "Записване..." : "Запази")
             </button>
         </div>
@@ -177,6 +177,7 @@ else
     string? errorMessage;
     string? validationMessage;
     bool isSaving;
+    bool DisableSaveButton => isSaving || summary is null;
 
     ElementReference cashInput;
     ElementReference cardInput;
@@ -355,7 +356,7 @@ else
             return;
         }
         
-        var result = await EventSvc.UpdateStartingPettyCash(day.EventDayId, amount);
+        var result = await EventSvc.UpdateStartingPettyCashAsync(day.EventDayId, amount);
         
         if(!result.Success)
         {

--- a/MySalesTracker.Web/Components/Pages/EventDay.razor
+++ b/MySalesTracker.Web/Components/Pages/EventDay.razor
@@ -15,13 +15,12 @@
 }
 else
 {
-    <h2>@day.Date.ToDateTime(TimeOnly.MinValue).ToString("dd.MM dddd", Bg)</h2>
-
-    <p><a href="/events">⬅️ Събития</a> | @day.Event.Name</p>
-
-    <div class="mb-3">
+    <div class="mb-3 d-flex justify-content-start align-items-center gap-3">
+        <h2 class="mb-0">@day.Date.ToDateTime(TimeOnly.MinValue).ToString("dd.MM dddd", Bg)</h2>
         <a href="/day/@id/report" class="btn btn-outline-primary">Дневен Отчет</a>
     </div>
+
+    <p><a href="/events">⬅️ Събития</a> | @day.Event.Name</p>    
 
     <div class="mb-2 d-flex gap-3 flex-wrap align-items-center">
         <select @bind="productId" @bind:after="OnProductChanged" class="form-select" style="width: 16.5rem">
@@ -56,9 +55,9 @@ else
                @bind="discountText" @bind:event="oninput" @bind:after="ClearValidationMessage" />
 
         <!-- Note input -->
-        <input type="text" inputmode="text" enterkeyhint="done" autocomplete="off"
+        @* <input type="text" inputmode="text" enterkeyhint="done" autocomplete="off"
                placeholder="Бележка…" class="form-control" style="width: 8rem"
-               @bind="note" @bind:event="oninput" />
+               @bind="note" @bind:event="oninput" /> *@
 
         <button class="btn btn-primary" style="width: 8rem; height: 2.75rem" @onclick="Add" disabled="@DisableAddButton">
             @(editingSaleId.HasValue ? "Запази" : "Добави")
@@ -79,7 +78,7 @@ else
     @foreach (var summary in brandSummaries)
     {
       <h4 class="mt-4">@summary.Brand.GetDisplayName()</h4>
-      <table class="table table-striped align-middle compact-table">
+      <table class="table table-striped align-middle compact-table" style="margin-left: -1.5rem; margin-right: -1.5rem;">
           <thead class="table-warning">
               <tr>
                   <th class="px-3">Час</th>
@@ -87,7 +86,7 @@ else
                   <th class="px-3">бр.</th>
                   <th class="px-3">Цена</th>
                   <th class="px-3">Отст.</th>
-                  <th class="px-3">Бележка</th>
+                  @* <th class="px-3">Бележка</th> *@
                   <th class="px-3">Действия</th>
               </tr>
           </thead>
@@ -99,8 +98,8 @@ else
                       <td class="px-3">@s.Product.Name</td>
                       <td class="px-3">@s.QuantityUnits</td>
                       <td class="px-3">@s.Price.ToString("0.00")</td>
-                      <td class="px-3">@s.DiscountValue.ToString("0.00")</td>
-                      <td class="px-3">@s.Notes</td>
+                      <td class="px-3" style="color: @(s.DiscountValue > 0 ? "inherit" : "lightgray")">@s.DiscountValue.ToString("0.00")</td>
+                      @* <td class="px-3">@s.Notes</td> *@
                       <td class="px-3 text-end">
                           <div class="btn-group" role="group">
                               <button class="btn btn-outline-primary btn-sm" @onclick="() => EditSale(s.SaleId)">Edit</button>
@@ -127,6 +126,7 @@ else
     Domain.Entities.EventDay? day;
     List<Product> products = new();
     List<PriceRule> priceOptions = new();
+    List<PriceRule> allPriceRules = new();
     List<BrandSalesSummary> brandSummaries = new();
     HubConnection? hubConnection;
 
@@ -141,12 +141,13 @@ else
     int qty = 1;
     string? validationMessage;
     int? editingSaleId;   // Track if editing a sale
+    double scrollPositionBeforeEdit = 0;
 
     static readonly CultureInfo Bg = CultureInfo.GetCultureInfo("bg-BG");
 
     bool DisableAddButton => !string.IsNullOrEmpty(validationMessage);
 
-    
+
     // "FLE Standard Time" is the Windows time zone ID for Sofia, Bulgaria (UTC+2/UTC+3)
     static readonly TimeZoneInfo SofiaTimeZone = TimeZoneInfo.FindSystemTimeZoneById("FLE Standard Time");
 
@@ -155,41 +156,52 @@ else
     protected override async Task OnInitializedAsync()
     {
         day = await EventSvc.GetEventDayByIdAsync(id);
-        if (day == null)
-        {
-            // EventDay not found - the loading message will remain visible            
-            return;
-        }
+        if (day == null) return;
 
         products = await ProductSvc.GetActiveProductsAsync();
+
+        allPriceRules = await PriceRuleSvc.GetAllPriceRules();
 
         await ReloadSalesAsync();
         await EnsureHubConnectionAsync();
     }
 
-    async Task OnProductChanged()
+    void OnProductChanged()
     {
         if (selectedProduct?.Brand == Brand.Ceramics)
         {
             priceOptions.Clear();
-            price = null; priceText = null; // force manual entry
-            qty = 1;                        // no rules => default 1
+            price = null;
+            priceText = null;
+            qty = 1; // no rules => default 1
         }
         else
         {
             priceOptions = productId is null
                 ? new()
-                : await ProductSvc.GetPriceRulesForProductAsync(productId.Value);
-            price = null; priceText = null; qty = 1;
+                : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList();
+
+            var defaultPrice = (selectedProduct?.Brand, selectedProduct?.Name) switch
+            {
+                (Brand.Totem, "Бандани") => 40.00m,
+                (Brand.Totem, "Ръкавици") => 35.00m,
+                (Brand.Candles, _) => 19.00m,
+                _ => 0m
+            };
+
+            price = priceOptions.FirstOrDefault(r => r.Price == defaultPrice)?.Price 
+                    ?? priceOptions.FirstOrDefault()?.Price;
+            priceText = null; 
+            qty = 1;
         }
 
         ClearValidationMessage();
-        StateHasChanged();
     }
 
     async Task Add()
     {
         if (day is null) return;
+
         if (productId is null)
         {
             validationMessage = "Посочи какво продаваш, на врачка ли ще ходиш после?";
@@ -235,8 +247,9 @@ else
             return;
         }
 
-        var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
+        var unitsPerSale = await PriceRuleSvc.GetUnitsForProduct(productId.Value, price.Value, day.Date);
 
+        var savedScrollPosition = 0.0;
         if (editingSaleId.HasValue)
         {
             // Update existing sale
@@ -249,6 +262,8 @@ else
                 note,
                 unitsPerSale.PriceRuleId);
 
+            savedScrollPosition = scrollPositionBeforeEdit;
+            scrollPositionBeforeEdit = 0;
             editingSaleId = null;
         }
         else
@@ -265,32 +280,25 @@ else
 
         await ReloadSalesAsync();
 
+        if (savedScrollPosition > 0)
+        {
+            await Task.Delay(100); // Small delay to let UI update
+            await JSRuntime.InvokeVoidAsync("window.scrollTo", new { top = savedScrollPosition, behavior = "smooth" });
+        }
+
         // Reset quick inputs but keep current product selection
         price = null; priceText = null; discountText = null; note = null; qty = 1;
-        await OnProductChanged(); // repopulate priceOptions for the currently selected product
+        OnProductChanged(); // repopulate priceOptions for the currently selected product
     }
 
     private async Task OnPriceChanged()
     {
-        if (productId is null || day is null) return;
+        if (productId is null || day is null || price is null) return;
 
-        if (selectedProduct?.Brand == Brand.Ceramics)
-        {
-            // Parse typed price using current culture
-            price = DecimalParsingHelper.TryParseDecimal(priceText, out var parsed)
-                ? parsed
-                : null;
-            qty = 1;
-        }
-        else if (price is not null)
-        {
-            var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
-            qty = unitsPerSale.Units;
-        }
+        var unitsPerSale = await PriceRuleSvc.GetUnitsForProduct(productId.Value, price.Value, day.Date);
+        qty = unitsPerSale.Units;
 
         ClearValidationMessage();
-
-        StateHasChanged();
     }
 
     void ClearValidationMessage()
@@ -360,18 +368,22 @@ else
         var sale = await SaleSvc.GetSaleByIdAsync(saleId);
         if (sale is null) return;
 
+        scrollPositionBeforeEdit = await JSRuntime.InvokeAsync<double>("eval", "window.scrollY");
+
         editingSaleId = saleId;
         productId = sale.ProductId;
         
-        await OnProductChanged();
+        OnProductChanged();
 
         price = sale.Price;
         priceText = sale.Price.ToString("0.00", Bg);
         discountText = sale.DiscountValue > 0 ? sale.DiscountValue.ToString("0.00", Bg) : null;
         note = sale.Notes;
 
-
         StateHasChanged();
+
+        // Scroll to top smoothly
+        await JSRuntime.InvokeVoidAsync("window.scrollTo", new { top = 0, behavior = "smooth" });
     }
 
     private async Task DeleteSale(int saleId)

--- a/MySalesTracker.Web/Components/Pages/EventDay.razor
+++ b/MySalesTracker.Web/Components/Pages/EventDay.razor
@@ -147,7 +147,7 @@ else
 
     bool DisableAddButton => !string.IsNullOrEmpty(validationMessage);
 
-
+    
     // "FLE Standard Time" is the Windows time zone ID for Sofia, Bulgaria (UTC+2/UTC+3)
     static readonly TimeZoneInfo SofiaTimeZone = TimeZoneInfo.FindSystemTimeZoneById("FLE Standard Time");
 
@@ -160,13 +160,13 @@ else
 
         products = await ProductSvc.GetActiveProductsAsync();
 
-        allPriceRules = await PriceRuleSvc.GetAllPriceRules();
+        allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync(day.Date);
 
         await ReloadSalesAsync();
         await EnsureHubConnectionAsync();
     }
 
-    void OnProductChanged()
+    async Task OnProductChanged()
     {
         if (selectedProduct?.Brand == Brand.Ceramics)
         {
@@ -179,8 +179,11 @@ else
         {
             priceOptions = productId is null
                 ? new()
-                : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList();
+                : await ProductSvc.GetPriceRulesForProductAsync(productId.Value);
 
+
+            // TODO: Hard-coded product names and prices are used for setting default values. This creates a tight coupling 
+            // between the UI and business logic, making the code fragile to product name changes in the database.
             var defaultPrice = (selectedProduct?.Brand, selectedProduct?.Name) switch
             {
                 (Brand.Totem, "Бандани") => 40.00m,
@@ -196,6 +199,7 @@ else
         }
 
         ClearValidationMessage();
+        StateHasChanged();
     }
 
     async Task Add()
@@ -247,7 +251,7 @@ else
             return;
         }
 
-        var unitsPerSale = await PriceRuleSvc.GetUnitsForProduct(productId.Value, price.Value, day.Date);
+        var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
 
         var savedScrollPosition = 0.0;
         if (editingSaleId.HasValue)
@@ -288,17 +292,30 @@ else
 
         // Reset quick inputs but keep current product selection
         price = null; priceText = null; discountText = null; note = null; qty = 1;
-        OnProductChanged(); // repopulate priceOptions for the currently selected product
+        await OnProductChanged(); // repopulate priceOptions for the currently selected product
     }
 
     private async Task OnPriceChanged()
     {
-        if (productId is null || day is null || price is null) return;
+        if (productId is null || day is null) return;
 
-        var unitsPerSale = await PriceRuleSvc.GetUnitsForProduct(productId.Value, price.Value, day.Date);
-        qty = unitsPerSale.Units;
+        if (selectedProduct?.Brand == Brand.Ceramics)
+        {
+            // Parse typed price using current culture
+            price = DecimalParsingHelper.TryParseDecimal(priceText, out var parsed)
+                ? parsed
+                : null;
+            qty = 1;
+        }
+        else if (price is not null)
+        {
+            var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
+            qty = unitsPerSale.Units;
+        }
 
         ClearValidationMessage();
+
+        StateHasChanged();
     }
 
     void ClearValidationMessage()
@@ -373,7 +390,7 @@ else
         editingSaleId = saleId;
         productId = sale.ProductId;
         
-        OnProductChanged();
+        await OnProductChanged();
 
         price = sale.Price;
         priceText = sale.Price.ToString("0.00", Bg);

--- a/MySalesTracker.Web/Components/Pages/Events.razor
+++ b/MySalesTracker.Web/Components/Pages/Events.razor
@@ -69,8 +69,8 @@
 
         /* TODO: @IvayloK - replace the lines above if you need to reload all the events and keep the data updated on all the devices
         in cases where other users might have created events simultaneously */
-        //await EventSvc.CreateEvent(name, start, end);
-        //events = await EventSvc.GetAllEvents(); // Reload all events
+        //await EventSvc.CreateEventAsync(name, start, end);
+        //events = await EventSvc.GetAllEAsyncvents(); // Reload all events
         
         // Reset form
         name = $"Базар {DateOnly.FromDateTime(DateTime.Today)}";

--- a/MySalesTracker.Web/appsettings.json
+++ b/MySalesTracker.Web/appsettings.json
@@ -14,6 +14,6 @@
     },
     "AppSettings": {
         "AppName": "MySalesTracker",
-        "Version": "1.0.0-beta"
+        "Version": "1.1.0-beta"
     }
 }

--- a/MySalesTracker.Web/web.config
+++ b/MySalesTracker.Web/web.config
@@ -9,7 +9,7 @@
                   arguments=".\MySalesTracker.Web.dll"
                   stdoutLogEnabled="true"
                   stdoutLogFile="..\logs\stdout"
-                  hostingModel="outofprocess">
+                  hostingModel="OutOfProcess">
         <environmentVariables>
           <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Production" />
         </environmentVariables>


### PR DESCRIPTION
- The 'Бележка' section has been removed from both the tables and the input section.
- The 'Дневен отчет' button was moved along the right side of the date on the top of the Event day page.
- Default prices were added for all of the products except the ceramic.
- iOS price menu rendering issue because of an async call to the server to load price rules was resolved:
    
    Faced with iPhone 16 Pro, PWA installed.
    - You pick Product.
    - Then tap Price:
      - first tap → list briefly opens and immediately closes
      - second tap → list stays open and you can select.

- version updated to 1.1.0-beta