### PR TITLE
Fix Price Filtering, correct Matches prices.

### DIFF
--- a/MySalesTracker.Application/Interfaces/IProductRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IProductRepository.cs
@@ -4,6 +4,4 @@ namespace MySalesTracker.Application.Interfaces;
 public interface IProductRepository
 {
     Task<List<Product>> GetActiveProductsAsync(CancellationToken ct);
-
-    Task<List<PriceRule>> GetPriceRulesForProductAsync(int productId, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Services/ProductService.cs
+++ b/MySalesTracker.Application/Services/ProductService.cs
@@ -26,27 +26,4 @@ public sealed class ProductService(IProductRepository productRepository, ILogger
             throw;
         }
     }
-
-    /// <summary>
-    /// Gets price rules for a specific product.
-    /// </summary>
-    /// <param name="productId">The ID of the product.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>
-    /// A list of <see cref="PriceRule"/> objects associated with the specified product,
-    /// ordered by <see cref="PriceRule.SortOrder"/> ascending for display consistency.
-    /// Returns an empty list if the product has no price rules.
-    /// </returns>
-    public async Task<List<PriceRule>> GetPriceRulesForProductAsync(int productId, CancellationToken ct = default)
-    {
-        try
-        {
-            return await productRepository.GetPriceRulesForProductAsync(productId, ct);
-        }
-        catch (Exception ex)
-        {
-            logger.LogError(ex, "Failed to retrieve price rules for Product {ProductId}", productId);
-            throw;
-        }
-    }
 }

--- a/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
+++ b/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
@@ -40,7 +40,7 @@ public static class DataSeeder
             PR(pBags, 6.00m, 3, 3), PR(pBags, 8.00m, 4, 4)
         );
 
-        // Matches (Gora brand): 7→1, 14→2, 21→3, 28→4
+        // Matches (Gora brand): 6→1, 12→2, 18→3, 24→4
         context.PriceRules.AddRange(
             PR(pMatches, 6.00m, 1, 1), PR(pMatches, 12.00m, 2, 2),
             PR(pMatches, 18.00m, 3, 3), PR(pMatches, 24.00m, 4, 4)

--- a/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
+++ b/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
@@ -27,10 +27,11 @@ public static class DataSeeder
 
         var effectiveFrom = new DateOnly(2020, 1, 1);
 
-        // Candles (Gora brand): 19→1, 29→1, 38→2, 57→3
+        // Candles (Gora brand): 19→1, 29→1, 38→2, 57→3, 60→2, 90→3
         context.PriceRules.AddRange(
-            PR(pCandle, 19.00m, 1, 1), PR(pCandle, 29.00m, 1, 2),
-            PR(pCandle, 38.00m, 2, 3), PR(pCandle, 57.00m, 3, 4)
+            PR(pCandle, 19.00m, 1, 1), PR(pCandle, 30.00m, 1, 2),
+            PR(pCandle, 38.00m, 2, 3), PR(pCandle, 57.00m, 3, 4),
+            PR(pCandle, 60.00m, 2, 5), PR(pCandle, 90.00m, 3, 6)
         );
 
         // Bags (Gora brand): 2.00→1, 4.00→2, 6.00→3, 8.00→4
@@ -41,8 +42,8 @@ public static class DataSeeder
 
         // Matches (Gora brand): 7→1, 14→2, 21→3, 28→4
         context.PriceRules.AddRange(
-            PR(pMatches, 7.00m, 1, 1), PR(pMatches, 14.00m, 2, 2),
-            PR(pMatches, 21.00m, 3, 3), PR(pMatches, 28.00m, 4, 4)
+            PR(pMatches, 6.00m, 1, 1), PR(pMatches, 12.00m, 2, 2),
+            PR(pMatches, 18.00m, 3, 3), PR(pMatches, 24.00m, 4, 4)
         );
 
         // Gloves (Totem brand): 30/35/40→1, 70/80→2, 105/120→3

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
@@ -22,7 +22,7 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
-        var priceRule = await context.PriceRules
+        return await context.PriceRules
                 .Where(r => r.ProductId == productId
                     && r.Price == price
                     && r.EffectiveFrom <= onDate
@@ -30,7 +30,5 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
                 .OrderByDescending(r => r.EffectiveFrom)
                 .ThenBy(r => r.SortOrder)
                 .FirstOrDefaultAsync(ct);
-
-        return priceRule;
     }
 }

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
@@ -11,9 +11,11 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
-        return await context.PriceRules
+        var result =  await context.PriceRules
             .Where (r => r.EffectiveFrom <= onDate && (r.EffectiveTo == null || r.EffectiveTo >= onDate))
             .ToListAsync(ct);
+
+        return result;
     }
 
     public async Task<PriceRule?> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct)

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -17,14 +17,4 @@ internal class ProductRepository(IDbContextFactory<AppDbContext> contextFactory)
                 .OrderByDescending(p => p.Brand)
                 .ToListAsync(ct);
     }
-
-    public async Task<List<PriceRule>> GetPriceRulesForProductAsync(int productId, CancellationToken ct)
-    {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
-
-        return await context.PriceRules
-                .Where(r => r.ProductId == productId)
-                .OrderBy(r => r.SortOrder)
-                .ToListAsync(ct);
-    }
 }

--- a/MySalesTracker.Web/Components/Pages/EventDay.razor
+++ b/MySalesTracker.Web/Components/Pages/EventDay.razor
@@ -186,7 +186,7 @@ else
         {
             priceOptions = productId is null
                 ? new()
-                : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList<PriceRule>();
+                : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList();
 
             // TODO: Hard-coded product names and prices are used for setting default values. This creates a tight coupling 
             // between the UI and business logic, making the code fragile to product name changes in the database.

--- a/MySalesTracker.Web/Components/Pages/EventDay.razor
+++ b/MySalesTracker.Web/Components/Pages/EventDay.razor
@@ -186,8 +186,7 @@ else
         {
             priceOptions = productId is null
                 ? new()
-                : await ProductSvc.GetPriceRulesForProductAsync(productId.Value);
-
+                : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList<PriceRule>();
 
             // TODO: Hard-coded product names and prices are used for setting default values. This creates a tight coupling 
             // between the UI and business logic, making the code fragile to product name changes in the database.


### PR DESCRIPTION
### Fix Price Filtering, correct Matches prices

- Remove the GetPriceRulesForProductAsync method, as it breaks the price filtering based on the EffectiveTo date. 
- Correct the prices for the Matches, since they were set up incorrectly from the beginning.

### Description:
Refactored codebase to remove the `GetPriceRulesForProductAsync` method from `IProductRepository`, `ProductService`, and `ProductRepository`. Updated `EventDay.razor` to use the already populated in-memory `allPriceRules` list and a  LINQ query for filtering price rules, eliminating dependency on the removed method.

Modified `DataSeeder` to adjust and add `PriceRule` entries for candles and matches. Refactored `GetAllPriceRulesAsync` in `PriceRuleRepository` to introduce a temporary variable for clarity.

These changes streamline price rule management, reduce redundancy, and improve maintainability.
