### PR TITLE
Add price management and simplify price rules

### DIFF
--- a/MySalesTracker.Application/DTOs/ProductPricing.cs
+++ b/MySalesTracker.Application/DTOs/ProductPricing.cs
@@ -1,0 +1,23 @@
+using MySalesTracker.Domain.Enums;
+
+namespace MySalesTracker.Application.DTOs;
+
+public sealed record ProductPricing(
+    int ProductId,
+    string ProductName,
+    Brand Brand,
+    bool IsFreePrice,
+    IReadOnlyList<PriceRuleDetails> CurrentRules);
+
+public sealed record PriceRuleDetails(
+    decimal Price,
+    Currency Currency,
+    int UnitsPerSale,
+    int SortOrder,
+    bool IsDefault);
+
+public sealed record UpdateProductPriceRulesRequest(
+    int ProductId,
+    IReadOnlyList<PriceRuleInput> Rules);
+
+public sealed record PriceRuleInput(decimal Price, int UnitsPerSale, bool IsDefault);

--- a/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IPriceRuleRepository.cs
@@ -1,9 +1,8 @@
 using MySalesTracker.Domain.Entities;
-using MySalesTracker.Domain.Models;
-
 namespace MySalesTracker.Application.Interfaces;
 public interface IPriceRuleRepository
 {
-    Task<PriceRule?> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct);
-    Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct);
+    Task<PriceRule?> GetRuleForProductAsync(int productId, decimal price, CancellationToken ct);
+    Task<List<PriceRule>> GetAllPriceRulesAsync(CancellationToken ct);
+    Task ReplacePriceRulesAsync(int productId, IReadOnlyCollection<PriceRule> priceRules, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Interfaces/IProductRepository.cs
+++ b/MySalesTracker.Application/Interfaces/IProductRepository.cs
@@ -4,4 +4,6 @@ namespace MySalesTracker.Application.Interfaces;
 public interface IProductRepository
 {
     Task<List<Product>> GetActiveProductsAsync(CancellationToken ct);
+    Task<List<Product>> GetActiveProductsWithPriceRulesAsync(CancellationToken ct);
+    Task<Product?> GetActiveProductWithPriceRulesAsync(int productId, CancellationToken ct);
 }

--- a/MySalesTracker.Application/Interfaces/ISaleRepository.cs
+++ b/MySalesTracker.Application/Interfaces/ISaleRepository.cs
@@ -6,6 +6,6 @@ public interface ISaleRepository
     Task<List<Sale>> GetSalesByEventDay(int eventDayId, CancellationToken ct = default);
     Task<Sale?> GetSaleByIdAsync(int saleId, CancellationToken ct = default);
     Task<Sale> CreateSaleAsync(Sale sale, CancellationToken ct = default);
-    Task<Sale> UpdateSaleAsync(int saleId, decimal price, int quantityUnits, decimal discountValue, string? notes, int? priceRuleId, CancellationToken ct = default);
+    Task<Sale> UpdateSaleAsync(int saleId, decimal price, int quantityUnits, decimal discountValue, string? notes, CancellationToken ct = default);
     Task<bool> DeleteSaleAsync(int saleId, CancellationToken ct = default);
 }

--- a/MySalesTracker.Application/Services/PriceRuleService.cs
+++ b/MySalesTracker.Application/Services/PriceRuleService.cs
@@ -1,44 +1,40 @@
 using Microsoft.Extensions.Logging;
+using MySalesTracker.Application.DTOs;
 using MySalesTracker.Application.Interfaces;
 using MySalesTracker.Domain.Entities;
-using MySalesTracker.Domain.Models;
+using MySalesTracker.Domain.Enums;
 
 namespace MySalesTracker.Application.Services;
 
-public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, ILogger<PriceRuleService> logger)
+public sealed class PriceRuleService(
+    IPriceRuleRepository priceRuleRepository,
+    IProductRepository productRepository,
+    ILogger<PriceRuleService> logger)
 {
     /// <summary>
-    /// Gets the number of units per sale for a given product, price, and date.
-    /// Returns 1 if no matching rule is found.
+    /// Gets the number of units for a configured product price.
     /// </summary>
     /// <param name="productId">The ID of the product.</param>
     /// <param name="price">The price to look up.</param>
-    /// <param name="onDate">The date to check for the price rule.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>
-    /// A <see cref="UnitsPerSale"/> containing the number of units and optional price rule ID.
-    /// Returns (1, null) if no matching rule is found, ensuring safe fallback behavior.
-    /// The rule is selected based on effective date range and sorted by EffectiveFrom descending, then SortOrder ascending.
-    /// </returns>
-    public async Task<UnitsPerSale> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct = default)
+    /// <returns>The configured units, or null when the price is no longer available.</returns>
+    public async Task<int?> GetUnitsForProductAsync(int productId, decimal price, CancellationToken ct = default)
     {
         try
         {
-            var priceRule = await priceRuleRepository.GetUnitsForProductAsync(productId, price, onDate, ct);
+            var priceRule = await priceRuleRepository.GetRuleForProductAsync(productId, price, ct);
 
             if (priceRule is null)
             {
-                logger.LogWarning("No price rule found for Product {ProductId}, Price {Price}, Date {OnDate}. Defaulting to 1 unit per sale.", productId, price, onDate);
-                return new UnitsPerSale(1, null);
+                logger.LogWarning("No current price rule found for Product {ProductId}, Price {Price}.", productId, price);
+                return null;
             }
 
-            // Safeguard against zero units until validation is implemented
-            var units = priceRule.UnitsPerSale == 0 ? 1 : priceRule.UnitsPerSale;
-            return new UnitsPerSale(units, priceRule.PriceRuleId);
+            return priceRule.UnitsPerSale == 0 ? 1 : priceRule.UnitsPerSale;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to get units for Product {ProductId}, Price {Price}, Date {Date}", productId, price, onDate);
+            logger.LogError(ex, "Failed to get units for Product {ProductId}, Price {Price}", productId, price);
             throw;
         }
     }
@@ -51,11 +47,11 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
     /// <returns>
     /// A list of all <see cref="PriceRule"/> entities. Returns an empty list if an error occurs.
     /// </returns>
-    public async Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct = default)
+    public async Task<List<PriceRule>> GetAllPriceRulesAsync(CancellationToken ct = default)
     {
         try
         {
-            return await priceRuleRepository.GetAllPriceRulesAsync(onDate, ct);
+            return await priceRuleRepository.GetAllPriceRulesAsync(ct);
         }
         catch (Exception ex)
         {
@@ -63,4 +59,123 @@ public sealed class PriceRuleService(IPriceRuleRepository priceRuleRepository, I
             return [];
         }
     }
+
+    public async Task<List<ProductPricing>> GetProductPricingAsync(CancellationToken ct = default)
+    {
+        var products = await productRepository.GetActiveProductsWithPriceRulesAsync(ct);
+        return [.. products.Select(MapProductPricing)];
+    }
+
+    public async Task<ServiceResult<bool>> UpdateProductPriceRulesAsync(
+        UpdateProductPriceRulesRequest request,
+        CancellationToken ct = default)
+    {
+        var validationError = ValidateRequest(request);
+        if (validationError is not null)
+        {
+            return ServiceResult<bool>.FailureResult(validationError);
+        }
+
+        var product = await productRepository.GetActiveProductWithPriceRulesAsync(request.ProductId, ct);
+        if (product is null)
+        {
+            return ServiceResult<bool>.FailureResult("Продуктът не е намерен.");
+        }
+
+        if (product.Brand == Brand.Ceramics)
+        {
+            return ServiceResult<bool>.FailureResult("Керамиката използва свободна цена и няма ценови правила.");
+        }
+
+        var priceRules = request.Rules
+            .Select((rule, index) => new PriceRule
+            {
+                ProductId = request.ProductId,
+                Price = rule.Price,
+                Currency = Currency.EUR,
+                UnitsPerSale = rule.UnitsPerSale,
+                SortOrder = index + 1,
+                IsDefault = rule.IsDefault
+            })
+            .ToList();
+
+        try
+        {
+            await priceRuleRepository.ReplacePriceRulesAsync(
+                request.ProductId,
+                priceRules,
+                ct);
+
+            return ServiceResult<bool>.SuccessResult(true, "Цените са обновени.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogWarning(ex, "Price rules could not be updated for Product {ProductId}", request.ProductId);
+            return ServiceResult<bool>.FailureResult(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to update price rules for Product {ProductId}", request.ProductId);
+            return ServiceResult<bool>.FailureResult("Цените не можаха да бъдат обновени.");
+        }
+    }
+
+    private static string? ValidateRequest(UpdateProductPriceRulesRequest request)
+    {
+        if (request.Rules.Count == 0)
+        {
+            return "Добавете поне една цена.";
+        }
+
+        if (request.Rules.Count(r => r.IsDefault) != 1)
+        {
+            return "Изберете точно една основна цена.";
+        }
+
+        if (request.Rules.Any(r => r.Price <= 0 || r.Price > 9999.99m))
+        {
+            return "Цените трябва да бъдат между 0,01 и 9999,99 EUR.";
+        }
+
+        if (request.Rules.Any(r => decimal.Round(r.Price, 2) != r.Price))
+        {
+            return "Цените могат да имат най-много два знака след десетичната запетая.";
+        }
+
+        if (request.Rules.Any(r => r.UnitsPerSale <= 0))
+        {
+            return "Броят продукти трябва да бъде по-голям от нула.";
+        }
+
+        if (request.Rules.GroupBy(r => r.Price).Any(group => group.Count() > 1))
+        {
+            return "Една и съща цена не може да присъства повече от веднъж.";
+        }
+
+        return null;
+    }
+
+    private static ProductPricing MapProductPricing(Product product)
+    {
+        var currentRules = product.PriceRules
+            .OrderBy(rule => rule.SortOrder)
+            .ThenBy(rule => rule.Price)
+            .Select(MapPriceRule)
+            .ToList();
+
+        return new ProductPricing(
+            product.ProductId,
+            product.Name,
+            product.Brand,
+            product.Brand == Brand.Ceramics,
+            currentRules);
+    }
+
+    private static PriceRuleDetails MapPriceRule(PriceRule rule)
+        => new(
+            rule.Price,
+            rule.Currency,
+            rule.UnitsPerSale,
+            rule.SortOrder,
+            rule.IsDefault);
 }

--- a/MySalesTracker.Application/Services/SaleService.cs
+++ b/MySalesTracker.Application/Services/SaleService.cs
@@ -36,7 +36,6 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
     /// </summary>
     /// <param name="eventDayId">The ID of the event day.</param>
     /// <param name="productId">The ID of the product.</param>
-    /// <param name="priceRuleId">The ID of the price rule (optional).</param>
     /// <param name="unitPrice">The unit price of the product.</param>
     /// <param name="quantityUnits">The quantity of units sold.</param>
     /// <param name="discountValue">The discount value applied to the sale.</param>
@@ -52,7 +51,6 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
     public async Task<Sale> CreateSaleAsync(
         int eventDayId,
         int productId,
-        int? priceRuleId,
         decimal unitPrice,
         int quantityUnits,
         decimal discountValue = 0m,
@@ -73,7 +71,6 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
             {
                 EventDayId = eventDayId,
                 ProductId = productId,
-                PriceRuleId = priceRuleId,
                 Price = unitPrice,
                 QuantityUnits = quantityUnits,
                 DiscountValue = discountValue,
@@ -156,7 +153,6 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
     /// <param name="quantityUnits">The new quantity of units sold.</param>
     /// <param name="discountValue">The new discount value applied to the sale.</param>
     /// <param name="notes">The new notes for the sale.</param>
-    /// <param name="priceRuleId">The new price rule ID (optional).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// The updated <see cref="Sale"/> with <see cref="Product"/> navigation loaded.
@@ -172,7 +168,6 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
         int quantityUnits,
         decimal discountValue,
         string? notes,
-        int? priceRuleId,
         CancellationToken ct = default)
     {
         try
@@ -186,7 +181,7 @@ public sealed class SaleService(ISaleRepository saleRepository, ILogger<SaleServ
                 saleId, eventDayId, unitPrice, quantityUnits);
 
             var updatedSale = await saleRepository.UpdateSaleAsync(
-                saleId, unitPrice, quantityUnits, discountValue, notes, priceRuleId, ct);
+                saleId, unitPrice, quantityUnits, discountValue, notes, ct);
 
             await notificationService.NotifySaleCreatedAsync(eventDayId, saleId, ct);
 

--- a/MySalesTracker.Domain/Entities/PriceRule.cs
+++ b/MySalesTracker.Domain/Entities/PriceRule.cs
@@ -21,11 +21,7 @@ public sealed class PriceRule
 
     public int SortOrder { get; init; }
 
+    public bool IsDefault { get; init; }
+
     public Product Product { get; init; } = null!;
-
-    [Column(TypeName = "date")]
-    public DateOnly EffectiveFrom { get; init; } = DateOnly.FromDateTime(DateTime.UtcNow);
-
-    [Column(TypeName = "date")]
-    public DateOnly? EffectiveTo { get; init; }
 }

--- a/MySalesTracker.Domain/Entities/Sale.cs
+++ b/MySalesTracker.Domain/Entities/Sale.cs
@@ -17,10 +17,6 @@ public sealed class Sale
     public int ProductId { get; init; }
     public Product Product { get; init; } = null!;
 
-    [ForeignKey("PriceRule")]
-    public int? PriceRuleId { get; init; }
-    public PriceRule? PriceRule { get; init; }
-
     [Column(TypeName = "decimal(6,2)")]
     public decimal Price { get; init; }
 

--- a/MySalesTracker.Domain/Models/UnitsPerSale.cs
+++ b/MySalesTracker.Domain/Models/UnitsPerSale.cs
@@ -1,3 +1,0 @@
-namespace MySalesTracker.Domain.Models;
-
-public record UnitsPerSale(int Units, int? PriceRuleId);

--- a/MySalesTracker.Infrastructure/Migrations/20260818220232_AddPriceRuleDefault.Designer.cs
+++ b/MySalesTracker.Infrastructure/Migrations/20260818220232_AddPriceRuleDefault.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySalesTracker.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using MySalesTracker.Infrastructure.Persistence;
 namespace MySalesTracker.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818220232_AddPriceRuleDefault")]
+    partial class AddPriceRuleDefault
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -151,6 +154,12 @@ namespace MySalesTracker.Infrastructure.Migrations
                         .HasColumnType("int")
                         .HasDefaultValue(0);
 
+                    b.Property<DateOnly>("EffectiveFrom")
+                        .HasColumnType("date");
+
+                    b.Property<DateOnly?>("EffectiveTo")
+                        .HasColumnType("date");
+
                     b.Property<bool>("IsDefault")
                         .HasColumnType("bit");
 
@@ -168,12 +177,11 @@ namespace MySalesTracker.Infrastructure.Migrations
 
                     b.HasKey("PriceRuleId");
 
-                    b.HasIndex("ProductId")
+                    b.HasIndex("ProductId", "EffectiveFrom")
                         .IsUnique()
                         .HasFilter("[IsDefault] = 1");
 
-                    b.HasIndex("ProductId", "Price")
-                        .IsUnique();
+                    b.HasIndex("ProductId", "Price");
 
                     b.ToTable("PriceRules");
                 });
@@ -232,6 +240,9 @@ namespace MySalesTracker.Infrastructure.Migrations
                     b.Property<decimal>("Price")
                         .HasColumnType("decimal(6,2)");
 
+                    b.Property<int?>("PriceRuleId")
+                        .HasColumnType("int");
+
                     b.Property<int>("ProductId")
                         .HasColumnType("int");
 
@@ -241,6 +252,8 @@ namespace MySalesTracker.Infrastructure.Migrations
                     b.HasKey("SaleId");
 
                     b.HasIndex("EventDayId");
+
+                    b.HasIndex("PriceRuleId");
 
                     b.HasIndex("ProductId");
 
@@ -299,6 +312,10 @@ namespace MySalesTracker.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
+                    b.HasOne("MySalesTracker.Domain.Entities.PriceRule", "PriceRule")
+                        .WithMany()
+                        .HasForeignKey("PriceRuleId");
+
                     b.HasOne("MySalesTracker.Domain.Entities.Product", "Product")
                         .WithMany()
                         .HasForeignKey("ProductId")
@@ -306,6 +323,8 @@ namespace MySalesTracker.Infrastructure.Migrations
                         .IsRequired();
 
                     b.Navigation("EventDay");
+
+                    b.Navigation("PriceRule");
 
                     b.Navigation("Product");
                 });

--- a/MySalesTracker.Infrastructure/Migrations/20260818220232_AddPriceRuleDefault.cs
+++ b/MySalesTracker.Infrastructure/Migrations/20260818220232_AddPriceRuleDefault.cs
@@ -1,0 +1,83 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MySalesTracker.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriceRuleDefault : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDefault",
+                table: "PriceRules",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.Sql(
+                """
+                WITH EffectiveRules AS
+                (
+                    SELECT
+                        priceRule.PriceRuleId,
+                        priceRule.ProductId,
+                        priceRule.EffectiveFrom,
+                        priceRule.SortOrder,
+                        ROW_NUMBER() OVER
+                        (
+                            PARTITION BY priceRule.ProductId, priceRule.Price
+                            ORDER BY
+                                priceRule.EffectiveFrom DESC,
+                                priceRule.SortOrder,
+                                priceRule.PriceRuleId DESC
+                        ) AS VersionNumber
+                    FROM PriceRules AS priceRule
+                    WHERE priceRule.EffectiveFrom <= CAST(GETDATE() AS date)
+                        AND (priceRule.EffectiveTo IS NULL OR priceRule.EffectiveTo >= CAST(GETDATE() AS date))
+                ),
+                RankedRules AS
+                (
+                    SELECT
+                        priceRule.PriceRuleId,
+                        ROW_NUMBER() OVER
+                        (
+                            PARTITION BY priceRule.ProductId
+                            ORDER BY
+                                priceRule.SortOrder,
+                                priceRule.EffectiveFrom DESC,
+                                priceRule.PriceRuleId
+                        ) AS RowNumber
+                    FROM EffectiveRules AS priceRule
+                    WHERE priceRule.VersionNumber = 1
+                )
+                UPDATE priceRule
+                SET IsDefault = 1
+                FROM PriceRules AS priceRule
+                INNER JOIN RankedRules AS ranked ON ranked.PriceRuleId = priceRule.PriceRuleId
+                WHERE ranked.RowNumber = 1;
+                """);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceRules_ProductId_EffectiveFrom",
+                table: "PriceRules",
+                columns: new[] { "ProductId", "EffectiveFrom" },
+                unique: true,
+                filter: "[IsDefault] = 1");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PriceRules_ProductId_EffectiveFrom",
+                table: "PriceRules");
+
+            migrationBuilder.DropColumn(
+                name: "IsDefault",
+                table: "PriceRules");
+        }
+    }
+}

--- a/MySalesTracker.Infrastructure/Migrations/20260828132803_SimplifyPriceRules.Designer.cs
+++ b/MySalesTracker.Infrastructure/Migrations/20260828132803_SimplifyPriceRules.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MySalesTracker.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using MySalesTracker.Infrastructure.Persistence;
 namespace MySalesTracker.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828132803_SimplifyPriceRules")]
+    partial class SimplifyPriceRules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/MySalesTracker.Infrastructure/Migrations/20260828132803_SimplifyPriceRules.cs
+++ b/MySalesTracker.Infrastructure/Migrations/20260828132803_SimplifyPriceRules.cs
@@ -1,0 +1,203 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MySalesTracker.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class SimplifyPriceRules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sale_PriceRules_PriceRuleId",
+                table: "Sale");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sale_PriceRuleId",
+                table: "Sale");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PriceRules_ProductId_EffectiveFrom",
+                table: "PriceRules");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PriceRules_ProductId_Price",
+                table: "PriceRules");
+
+            migrationBuilder.DropColumn(
+                name: "PriceRuleId",
+                table: "Sale");
+
+            migrationBuilder.Sql(
+                """
+                DECLARE @Today date = CAST(GETDATE() AS date);
+
+                WITH ActiveCandidates AS
+                (
+                    SELECT
+                        priceRule.PriceRuleId,
+                        priceRule.ProductId,
+                        priceRule.Price,
+                        priceRule.EffectiveFrom
+                    FROM PriceRules AS priceRule
+                    WHERE priceRule.EffectiveFrom <= @Today
+                        AND (priceRule.EffectiveTo IS NULL OR priceRule.EffectiveTo >= @Today)
+                ),
+                LatestFallbackDates AS
+                (
+                    SELECT
+                        priceRule.ProductId,
+                        MAX(priceRule.EffectiveFrom) AS EffectiveFrom
+                    FROM PriceRules AS priceRule
+                    WHERE NOT EXISTS
+                    (
+                        SELECT 1
+                        FROM ActiveCandidates AS activeRule
+                        WHERE activeRule.ProductId = priceRule.ProductId
+                    )
+                    GROUP BY priceRule.ProductId
+                ),
+                Candidates AS
+                (
+                    SELECT
+                        activeRule.PriceRuleId,
+                        activeRule.ProductId,
+                        activeRule.Price,
+                        activeRule.EffectiveFrom
+                    FROM ActiveCandidates AS activeRule
+
+                    UNION ALL
+
+                    SELECT
+                        priceRule.PriceRuleId,
+                        priceRule.ProductId,
+                        priceRule.Price,
+                        priceRule.EffectiveFrom
+                    FROM PriceRules AS priceRule
+                    INNER JOIN LatestFallbackDates AS fallback
+                        ON fallback.ProductId = priceRule.ProductId
+                        AND fallback.EffectiveFrom = priceRule.EffectiveFrom
+                ),
+                RankedCandidates AS
+                (
+                    SELECT
+                        candidate.PriceRuleId,
+                        ROW_NUMBER() OVER
+                        (
+                            PARTITION BY candidate.ProductId, candidate.Price
+                            ORDER BY candidate.EffectiveFrom DESC, candidate.PriceRuleId DESC
+                        ) AS RowNumber
+                    FROM Candidates AS candidate
+                )
+                DELETE priceRule
+                FROM PriceRules AS priceRule
+                WHERE NOT EXISTS
+                (
+                    SELECT 1
+                    FROM RankedCandidates AS candidate
+                    WHERE candidate.PriceRuleId = priceRule.PriceRuleId
+                        AND candidate.RowNumber = 1
+                );
+
+                WITH RankedDefaults AS
+                (
+                    SELECT
+                        priceRule.PriceRuleId,
+                        ROW_NUMBER() OVER
+                        (
+                            PARTITION BY priceRule.ProductId
+                            ORDER BY
+                                CASE WHEN priceRule.IsDefault = 1 THEN 0 ELSE 1 END,
+                                priceRule.SortOrder,
+                                priceRule.PriceRuleId
+                        ) AS RowNumber
+                    FROM PriceRules AS priceRule
+                )
+                UPDATE priceRule
+                SET IsDefault = CASE WHEN ranked.RowNumber = 1 THEN 1 ELSE 0 END
+                FROM PriceRules AS priceRule
+                INNER JOIN RankedDefaults AS ranked
+                    ON ranked.PriceRuleId = priceRule.PriceRuleId;
+                """);
+
+            migrationBuilder.DropColumn(
+                name: "EffectiveFrom",
+                table: "PriceRules");
+
+            migrationBuilder.DropColumn(
+                name: "EffectiveTo",
+                table: "PriceRules");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceRules_ProductId",
+                table: "PriceRules",
+                column: "ProductId",
+                unique: true,
+                filter: "[IsDefault] = 1");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceRules_ProductId_Price",
+                table: "PriceRules",
+                columns: new[] { "ProductId", "Price" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PriceRules_ProductId",
+                table: "PriceRules");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PriceRules_ProductId_Price",
+                table: "PriceRules");
+
+            migrationBuilder.AddColumn<int>(
+                name: "PriceRuleId",
+                table: "Sale",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "EffectiveFrom",
+                table: "PriceRules",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "EffectiveTo",
+                table: "PriceRules",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sale_PriceRuleId",
+                table: "Sale",
+                column: "PriceRuleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceRules_ProductId_EffectiveFrom",
+                table: "PriceRules",
+                columns: new[] { "ProductId", "EffectiveFrom" },
+                unique: true,
+                filter: "[IsDefault] = 1");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PriceRules_ProductId_Price",
+                table: "PriceRules",
+                columns: new[] { "ProductId", "Price" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sale_PriceRules_PriceRuleId",
+                table: "Sale",
+                column: "PriceRuleId",
+                principalTable: "PriceRules",
+                principalColumn: "PriceRuleId");
+        }
+    }
+}

--- a/MySalesTracker.Infrastructure/Persistence/AppDbContext.cs
+++ b/MySalesTracker.Infrastructure/Persistence/AppDbContext.cs
@@ -28,7 +28,13 @@ public class AppDbContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder b)
     {
-        b.Entity<PriceRule>().HasIndex(r => new { r.ProductId, r.Price });
+        b.Entity<PriceRule>()
+            .HasIndex(r => new { r.ProductId, r.Price })
+            .IsUnique();
+        b.Entity<PriceRule>()
+            .HasIndex(r => r.ProductId)
+            .IsUnique()
+            .HasFilter("[IsDefault] = 1");
         b.Entity<Sale>().HasIndex(s => s.EventDayId);
 
         // That converter is needed to store Product.Brand as Bulgarian strings in the database

--- a/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
+++ b/MySalesTracker.Infrastructure/Persistence/DataSeeder.cs
@@ -5,9 +5,7 @@ using MySalesTracker.Domain.Enums;
 namespace MySalesTracker.Infrastructure.Persistence;
 
 /// <summary>
-/// Seeds the initial dataset we already maintain in Google Spreadsheets.
-/// It mirrors today's known structure and values (brands, products, and price rules)
-/// so the application starts with familiar data and can replace the spreadsheet workflow.
+/// Seeds the product catalog for an empty database.
 /// </summary>
 public static class DataSeeder
 {
@@ -24,54 +22,5 @@ public static class DataSeeder
 
         context.AddRange(pBandana, pGlove, pCandle, pMatches, pBags, pCeramic);
         await context.SaveChangesAsync();
-
-        var effectiveFrom = new DateOnly(2020, 1, 1);
-
-        // Candles (Gora brand): 19→1, 29→1, 38→2, 57→3, 60→2, 90→3
-        context.PriceRules.AddRange(
-            PR(pCandle, 19.00m, 1, 1), PR(pCandle, 30.00m, 1, 2),
-            PR(pCandle, 38.00m, 2, 3), PR(pCandle, 57.00m, 3, 4),
-            PR(pCandle, 60.00m, 2, 5), PR(pCandle, 90.00m, 3, 6)
-        );
-
-        // Bags (Gora brand): 2.00→1, 4.00→2, 6.00→3, 8.00→4
-        context.PriceRules.AddRange(
-            PR(pBags, 2.00m, 1, 1), PR(pBags, 4.00m, 2, 2),
-            PR(pBags, 6.00m, 3, 3), PR(pBags, 8.00m, 4, 4)
-        );
-
-        // Matches (Gora brand): 6→1, 12→2, 18→3, 24→4
-        context.PriceRules.AddRange(
-            PR(pMatches, 6.00m, 1, 1), PR(pMatches, 12.00m, 2, 2),
-            PR(pMatches, 18.00m, 3, 3), PR(pMatches, 24.00m, 4, 4)
-        );
-
-        // Gloves (Totem brand): 30/35/40→1, 70/80→2, 105/120→3
-        context.PriceRules.AddRange(
-            PR(pGlove, 30.00m, 1, 1), PR(pGlove, 35.00m, 1, 2),
-            PR(pGlove, 40.00m, 1, 3), PR(pGlove, 70.00m, 2, 4),
-            PR(pGlove, 80.00m, 2, 5), PR(pGlove, 105.00m, 3, 6),
-            PR(pGlove, 120.00m, 3, 7)
-        );
-
-        // Bandanas (Totem brand): 30/35/40→1, 70/80→2, 105/120→3
-        context.PriceRules.AddRange(
-            PR(pBandana, 30.00m, 1, 1), PR(pBandana, 35.00m, 1, 2), PR(pBandana, 40.00m, 1, 3),
-            PR(pBandana, 70.00m, 2, 4), PR(pBandana, 80.00m, 2, 5),
-            PR(pBandana, 105.00m, 3, 6), PR(pBandana, 120.00m, 3, 7)
-        );
-
-        await context.SaveChangesAsync();
-
-        static PriceRule PR(Product p, decimal price, int units, int sort)
-            => new()
-            {
-                Product = p,
-                ProductId = p.ProductId,
-                Price = price,
-                UnitsPerSale = units,
-                SortOrder = sort,
-                EffectiveFrom = new DateOnly(2020, 1, 1)
-            };
     }
 }

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/PriceRuleRepository.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using Microsoft.EntityFrameworkCore;
 using MySalesTracker.Application.Interfaces;
 using MySalesTracker.Domain.Entities;
@@ -7,28 +8,46 @@ internal class PriceRuleRepository(IDbContextFactory<AppDbContext> contextFactor
 {
     private readonly IDbContextFactory<AppDbContext> _contextFactory = contextFactory;
 
-    public async Task<List<PriceRule>> GetAllPriceRulesAsync(DateOnly onDate, CancellationToken ct)
-    {
-        await using var context = await _contextFactory.CreateDbContextAsync(ct);
-
-        var result =  await context.PriceRules
-            .Where (r => r.EffectiveFrom <= onDate && (r.EffectiveTo == null || r.EffectiveTo >= onDate))
-            .ToListAsync(ct);
-
-        return result;
-    }
-
-    public async Task<PriceRule?> GetUnitsForProductAsync(int productId, decimal price, DateOnly onDate, CancellationToken ct)
+    public async Task<List<PriceRule>> GetAllPriceRulesAsync(CancellationToken ct)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
 
         return await context.PriceRules
-                .Where(r => r.ProductId == productId
-                    && r.Price == price
-                    && r.EffectiveFrom <= onDate
-                    && (r.EffectiveTo == null || r.EffectiveTo >= onDate))
-                .OrderByDescending(r => r.EffectiveFrom)
-                .ThenBy(r => r.SortOrder)
-                .FirstOrDefaultAsync(ct);
+            .AsNoTracking()
+            .OrderBy(r => r.ProductId)
+            .ThenBy(r => r.SortOrder)
+            .ToListAsync(ct);
+    }
+
+    public async Task<PriceRule?> GetRuleForProductAsync(int productId, decimal price, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        return await context.PriceRules
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.ProductId == productId && r.Price == price, ct);
+    }
+
+    public async Task ReplacePriceRulesAsync(
+        int productId,
+        IReadOnlyCollection<PriceRule> priceRules,
+        CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        await using var transaction = await context.Database.BeginTransactionAsync(IsolationLevel.Serializable, ct);
+
+        var existingRules = await context.PriceRules
+            .Where(r => r.ProductId == productId)
+            .ToListAsync(ct);
+
+        if (existingRules.Count > 0)
+        {
+            context.PriceRules.RemoveRange(existingRules);
+            await context.SaveChangesAsync(ct);
+        }
+
+        context.PriceRules.AddRange(priceRules);
+        await context.SaveChangesAsync(ct);
+        await transaction.CommitAsync(ct);
     }
 }

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -18,4 +18,28 @@ internal class ProductRepository(IDbContextFactory<AppDbContext> contextFactory)
                 .OrderByDescending(p => p.Brand)
                 .ToListAsync(ct);
     }
+
+    public async Task<List<Product>> GetActiveProductsWithPriceRulesAsync(CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        return await context.Products
+            .AsNoTracking()
+            .Where(p => p.IsActive)
+            .Include(p => p.PriceRules)
+            .OrderBy(p => p.Brand)
+            .ThenBy(p => p.Name)
+            .ToListAsync(ct);
+    }
+
+    public async Task<Product?> GetActiveProductWithPriceRulesAsync(int productId, CancellationToken ct)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+
+        return await context.Products
+            .AsNoTracking()
+            .Where(p => p.IsActive && p.ProductId == productId)
+            .Include(p => p.PriceRules)
+            .SingleOrDefaultAsync(ct);
+    }
 }

--- a/MySalesTracker.Infrastructure/Persistence/Repositories/SaleRepository.cs
+++ b/MySalesTracker.Infrastructure/Persistence/Repositories/SaleRepository.cs
@@ -49,7 +49,6 @@ internal class SaleRepository(IDbContextFactory<AppDbContext> contextFactory) : 
         int quantityUnits,
         decimal discountValue,
         string? notes,
-        int? priceRuleId,
         CancellationToken ct = default)
     {
         await using var context = await _contextFactory.CreateDbContextAsync(ct);
@@ -60,8 +59,7 @@ internal class SaleRepository(IDbContextFactory<AppDbContext> contextFactory) : 
                 .SetProperty(s => s.Price, price)
                 .SetProperty(s => s.QuantityUnits, quantityUnits)
                 .SetProperty(s => s.DiscountValue, discountValue)
-                .SetProperty(s => s.Notes, notes)
-                .SetProperty(s => s.PriceRuleId, priceRuleId),
+                .SetProperty(s => s.Notes, notes),
                 ct);
 
         return await context.Sale

--- a/MySalesTracker.Web/Components/Layout/NavMenu.razor
+++ b/MySalesTracker.Web/Components/Layout/NavMenu.razor
@@ -42,6 +42,12 @@
                 </NavLink>
             </div>
             <div class="nav-item px-3">
+                <NavLink class="nav-link" href="admin/prices" title="Цени">
+                    <span class="bi bi-tags" aria-hidden="true"></span>
+                    <span class="nav-link-text">Цени</span>
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
                 <NavLink class="nav-link" href="weather" title="Дали вали">
                     <span class="bi bi-cloud-rain" aria-hidden="true"></span>
                     <span class="nav-link-text">Дали вали 👀</span>

--- a/MySalesTracker.Web/Components/Pages/EventDay.razor
+++ b/MySalesTracker.Web/Components/Pages/EventDay.razor
@@ -49,6 +49,12 @@ else
         {
             <select @bind="price" @bind:after="OnPriceChanged" class="form-select" style="width: 8rem">
                 <option value="">Цена…</option>
+                @if (editingSaleId.HasValue
+                    && price.HasValue
+                    && priceOptions.All(rule => rule.Price != price.Value))
+                {
+                    <option value="@price.Value">@price.Value (записана)</option>
+                }
                 @foreach (var r in priceOptions)
                 {
                     <option value="@r.Price">@r.Price</option>
@@ -191,6 +197,8 @@ else
     int qty = 1;
     string? validationMessage;
     int? editingSaleId;   // Track if editing a sale
+    decimal? editingOriginalPrice;
+    int? editingOriginalQuantityUnits;
     double scrollPositionBeforeEdit = 0;
     bool showSavedFeedback = false;
     bool isSaving = false;
@@ -213,7 +221,7 @@ else
 
         products = await ProductSvc.GetActiveProductsAsync();
 
-        allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync(day.Date);
+        allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync();
 
         await ReloadSalesAsync();
         await EnsureHubConnectionAsync();
@@ -221,6 +229,8 @@ else
 
     async Task OnProductChanged()
     {
+        allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync();
+
         if (selectedProduct?.Brand == Brand.Ceramics)
         {
             priceOptions.Clear();
@@ -233,17 +243,7 @@ else
                 ? new()
                 : allPriceRules.Where(r => r.ProductId == productId).OrderBy(r => r.SortOrder).ToList();
 
-            // TODO: Hard-coded product names and prices are used for setting default values. This creates a tight coupling 
-            // between the UI and business logic, making the code fragile to product name changes in the database.
-            var defaultPrice = (selectedProduct?.Brand, selectedProduct?.Name) switch
-            {
-                (Brand.Totem, "Бандани") => 40.00m,
-                (Brand.Totem, "Ръкавици") => 35.00m,
-                (Brand.Candles, _) => 19.00m,
-                _ => 0m
-            };
-
-            price = priceOptions.FirstOrDefault(r => r.Price == defaultPrice)?.Price 
+            price = priceOptions.FirstOrDefault(r => r.IsDefault)?.Price
                     ?? priceOptions.FirstOrDefault()?.Price;
             priceText = null;
         }
@@ -301,7 +301,34 @@ else
             return;
         }
 
-        var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
+        int unitsPerSale;
+        if (editingSaleId.HasValue && price == editingOriginalPrice)
+        {
+            unitsPerSale = editingOriginalQuantityUnits ?? 1;
+        }
+        else if (selectedProduct?.Brand == Brand.Ceramics)
+        {
+            unitsPerSale = 1;
+        }
+        else
+        {
+            var configuredUnits = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value);
+            if (!configuredUnits.HasValue)
+            {
+                allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync();
+                priceOptions = allPriceRules
+                    .Where(rule => rule.ProductId == productId.Value)
+                    .OrderBy(rule => rule.SortOrder)
+                    .ToList();
+                price = priceOptions.FirstOrDefault(rule => rule.IsDefault)?.Price
+                    ?? priceOptions.FirstOrDefault()?.Price;
+                validationMessage = "Цените са променени. Избери актуална цена и опитай отново.";
+                return;
+            }
+
+            unitsPerSale = configuredUnits.Value;
+        }
+
         isSaving = true;
         StateHasChanged();
 
@@ -315,23 +342,23 @@ else
                     editingSaleId.Value,
                     day.EventDayId,
                     price.Value,
-                    unitsPerSale.Units,
+                    unitsPerSale,
                     discount,
-                    note,
-                    unitsPerSale.PriceRuleId);
+                    note);
 
                 savedScrollPosition = scrollPositionBeforeEdit;
                 scrollPositionBeforeEdit = 0;
                 editingSaleId = null;
+                editingOriginalPrice = null;
+                editingOriginalQuantityUnits = null;
             }
             else
             {
                 await SaleSvc.CreateSaleAsync(
                     day.EventDayId,
                     productId.Value,
-                    unitsPerSale.PriceRuleId,
                     price.Value,
-                    unitsPerSale.Units,
+                    unitsPerSale,
                     discount,
                     note);
             }
@@ -380,9 +407,9 @@ else
         }
     }
 
-    private async Task OnPriceChanged()
+    private void OnPriceChanged()
     {
-        if (productId is null || day is null) return;
+        if (productId is null) return;
 
         if (selectedProduct?.Brand == Brand.Ceramics)
         {
@@ -391,14 +418,7 @@ else
                 ? parsed
                 : null;
         }
-        else if (price is not null)
-        {
-            var unitsPerSale = await PriceRuleSvc.GetUnitsForProductAsync(productId.Value, price.Value, day.Date);
-        }
-
         ClearValidationMessage();
-
-        StateHasChanged();
     }
 
     void ClearValidationMessage()
@@ -480,9 +500,14 @@ else
 
         editingSaleId = saleId;
         productId = sale.ProductId;
-        
-        //TODO: Uncomment once there is option to change the entire product with the edit. Currently the product stays as it is and only the price could be changed.
-        //await OnProductChanged();
+        editingOriginalPrice = sale.Price;
+        editingOriginalQuantityUnits = sale.QuantityUnits;
+
+        allPriceRules = await PriceRuleSvc.GetAllPriceRulesAsync();
+        priceOptions = allPriceRules
+            .Where(rule => rule.ProductId == sale.ProductId)
+            .OrderBy(rule => rule.SortOrder)
+            .ToList();
 
         price = sale.Price;
         priceText = sale.Price.ToString("0.00", Bg);
@@ -510,6 +535,8 @@ else
     private void CancelEdit()
     {
         editingSaleId = null;
+        editingOriginalPrice = null;
+        editingOriginalQuantityUnits = null;
         productId = null;
         price = null;
         priceText = null;

--- a/MySalesTracker.Web/Components/Pages/PriceAdministration.razor
+++ b/MySalesTracker.Web/Components/Pages/PriceAdministration.razor
@@ -1,0 +1,357 @@
+@page "/admin/prices"
+@attribute [Authorize]
+@inject PriceRuleService PriceRuleSvc
+@inject IJSRuntime JSRuntime
+
+<PageTitle>Цени</PageTitle>
+
+<div class="price-page-header">
+    <h2>Цени</h2>
+</div>
+
+<div class="brand-tabs" role="tablist" aria-label="Марка">
+    @foreach (var brand in BrandOrder)
+    {
+        <button type="button"
+                role="tab"
+                aria-selected="@(selectedBrand == brand)"
+                class="brand-tab @(selectedBrand == brand ? "brand-tab-active" : null)"
+                @onclick="() => SelectBrand(brand)">
+            @brand.GetDisplayName()
+        </button>
+    }
+</div>
+
+@if (!string.IsNullOrWhiteSpace(pageMessage))
+{
+    <div class="alert alert-success py-2" role="status">@pageMessage</div>
+}
+
+@if (!string.IsNullOrWhiteSpace(pageError))
+{
+    <div class="alert alert-danger py-2" role="alert">@pageError</div>
+}
+
+@if (isLoading)
+{
+    <p class="text-muted">Зареждане...</p>
+}
+else
+{
+    <section class="product-price-list" aria-label="Цени по продукти">
+        @foreach (var product in SelectedProducts)
+        {
+            var isEditing = editingProductId == product.ProductId;
+
+            <article class="product-price-card">
+                <div class="product-price-header">
+                    <div>
+                        <h3>@product.ProductName</h3>
+                        @if (product.IsFreePrice)
+                        {
+                            <span class="free-price-label">Свободна цена</span>
+                        }
+                        else if (product.CurrentRules.Count > 0)
+                        {
+                            <span class="current-price-label">Текущи цени</span>
+                        }
+                        else
+                        {
+                            <span class="text-muted">Няма активни цени</span>
+                        }
+                    </div>
+
+                    @if (!product.IsFreePrice && !isEditing)
+                    {
+                        <button type="button"
+                                class="btn btn-outline-primary btn-sm edit-price-button"
+                                @onclick="() => StartEditing(product)">
+                            <span class="bi bi-pencil" aria-hidden="true"></span>
+                            Промени
+                        </button>
+                    }
+                </div>
+
+                @if (product.IsFreePrice)
+                {
+                    <div class="free-price-state">
+                        <span class="bi bi-input-cursor-text" aria-hidden="true"></span>
+                        Цената се въвежда при продажба
+                    </div>
+                }
+                else if (isEditing)
+                {
+                    <div class="price-editor">
+                        <div class="editor-column-labels" aria-hidden="true">
+                            <span>Осн.</span>
+                            <span>Цена (EUR)</span>
+                            <span>бр.</span>
+                            <span></span>
+                        </div>
+
+                        @foreach (var rule in editableRules)
+                        {
+                            <div class="editable-rule-row">
+                                <input type="radio"
+                                       name="default-price"
+                                       title="Основна цена"
+                                       aria-label="Основна цена"
+                                       checked="@rule.IsDefault"
+                                       @onchange="() => SelectDefaultRule(rule)" />
+                                <input type="text"
+                                       inputmode="decimal"
+                                       class="form-control"
+                                       aria-label="Цена"
+                                       placeholder="0,00"
+                                       @bind="rule.PriceText"
+                                       @bind:event="oninput" />
+                                <input type="number"
+                                       inputmode="numeric"
+                                       min="1"
+                                       class="form-control units-input"
+                                       aria-label="Бройки"
+                                       @bind="rule.UnitsPerSale" />
+                                <button type="button"
+                                        class="remove-rule-button"
+                                        title="Премахни цена"
+                                        aria-label="Премахни цена"
+                                        disabled="@(editableRules.Count == 1)"
+                                        @onclick="() => RemoveRule(rule)">
+                                    <span class="bi bi-trash" aria-hidden="true"></span>
+                                </button>
+                            </div>
+                        }
+
+                        <button type="button" class="add-rule-button" @onclick="AddRule">
+                            <span class="bi bi-plus-lg" aria-hidden="true"></span>
+                            Добави цена
+                        </button>
+
+                        @if (!string.IsNullOrWhiteSpace(editorError))
+                        {
+                            <div class="editor-error" role="alert">@editorError</div>
+                        }
+
+                        <div class="editor-actions">
+                            <button type="button"
+                                    class="btn btn-primary btn-sm"
+                                    disabled="@isSaving"
+                                    @onclick="() => SaveChangesAsync(product)">
+                                @(isSaving ? "Записване..." : "Запази")
+                            </button>
+                            <button type="button"
+                                    class="btn btn-outline-secondary btn-sm"
+                                    disabled="@isSaving"
+                                    @onclick="CancelEditing">
+                                Откажи
+                            </button>
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    @if (product.CurrentRules.Count > 0)
+                    {
+                        <div class="current-price-rules">
+                            @foreach (var rule in product.CurrentRules)
+                            {
+                                <div class="current-rule-row">
+                                    <strong>@FormatPrice(rule.Price)</strong>
+                                    <span>@rule.UnitsPerSale бр.</span>
+                                    @if (rule.IsDefault)
+                                    {
+                                        <span class="default-price-label">Основна</span>
+                                    }
+                                </div>
+                            }
+                        </div>
+                    }
+
+                }
+            </article>
+        }
+    </section>
+}
+
+@code {
+    private static readonly Brand[] BrandOrder = [Brand.Totem, Brand.Ceramics, Brand.Candles];
+    private static readonly CultureInfo Bg = CultureInfo.GetCultureInfo("bg-BG");
+
+    private List<ProductPricing> products = [];
+    private readonly List<EditablePriceRule> editableRules = [];
+    private Brand selectedBrand = Brand.Totem;
+    private int? editingProductId;
+    private bool isLoading = true;
+    private bool isSaving;
+    private string? pageMessage;
+    private string? pageError;
+    private string? editorError;
+
+    private IEnumerable<ProductPricing> SelectedProducts
+        => products.Where(product => product.Brand == selectedBrand);
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadProductsAsync();
+    }
+
+    private async Task LoadProductsAsync()
+    {
+        isLoading = true;
+        pageError = null;
+
+        try
+        {
+            products = await PriceRuleSvc.GetProductPricingAsync();
+        }
+        catch
+        {
+            pageError = "Цените не можаха да бъдат заредени.";
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void SelectBrand(Brand brand)
+    {
+        selectedBrand = brand;
+        CancelEditing();
+        pageMessage = null;
+        pageError = null;
+    }
+
+    private void StartEditing(ProductPricing product)
+    {
+        editingProductId = product.ProductId;
+        pageMessage = null;
+        pageError = null;
+        editorError = null;
+        editableRules.Clear();
+
+        editableRules.AddRange(product.CurrentRules.Select(rule => new EditablePriceRule
+        {
+            PriceText = rule.Price.ToString("0.00", Bg),
+            UnitsPerSale = rule.UnitsPerSale,
+            IsDefault = rule.IsDefault
+        }));
+
+        if (editableRules.Count == 0)
+        {
+            editableRules.Add(new EditablePriceRule { UnitsPerSale = 1, IsDefault = true });
+        }
+        else if (editableRules.Count(rule => rule.IsDefault) != 1)
+        {
+            foreach (var rule in editableRules)
+            {
+                rule.IsDefault = false;
+            }
+
+            editableRules[0].IsDefault = true;
+        }
+    }
+
+    private void CancelEditing()
+    {
+        editingProductId = null;
+        editorError = null;
+        editableRules.Clear();
+        isSaving = false;
+    }
+
+    private void AddRule()
+    {
+        editableRules.Add(new EditablePriceRule
+        {
+            UnitsPerSale = 1,
+            IsDefault = editableRules.Count == 0
+        });
+    }
+
+    private void RemoveRule(EditablePriceRule rule)
+    {
+        if (editableRules.Count == 1)
+        {
+            return;
+        }
+
+        var wasDefault = rule.IsDefault;
+        editableRules.Remove(rule);
+        if (wasDefault)
+        {
+            editableRules[0].IsDefault = true;
+        }
+    }
+
+    private void SelectDefaultRule(EditablePriceRule selectedRule)
+    {
+        foreach (var rule in editableRules)
+        {
+            rule.IsDefault = ReferenceEquals(rule, selectedRule);
+        }
+    }
+
+    private async Task SaveChangesAsync(ProductPricing product)
+    {
+        editorError = null;
+        var inputs = new List<PriceRuleInput>(editableRules.Count);
+
+        foreach (var rule in editableRules)
+        {
+            if (!DecimalParsingHelper.TryParseDecimal(rule.PriceText, out var price))
+            {
+                editorError = "Въведете валидна цена за всеки ред.";
+                return;
+            }
+
+            inputs.Add(new PriceRuleInput(price, rule.UnitsPerSale, rule.IsDefault));
+        }
+
+        var confirmed = await JSRuntime.InvokeAsync<bool>(
+            "confirm",
+            $"Текущите цени за {product.ProductName} ще бъдат заменени. Да продължа ли?");
+
+        if (!confirmed)
+        {
+            return;
+        }
+
+        ServiceResult<bool> result;
+        isSaving = true;
+        try
+        {
+            result = await PriceRuleSvc.UpdateProductPriceRulesAsync(
+                new UpdateProductPriceRulesRequest(product.ProductId, inputs));
+        }
+        catch
+        {
+            editorError = "Цените не можаха да бъдат обновени.";
+            return;
+        }
+        finally
+        {
+            isSaving = false;
+        }
+
+        if (!result.Success)
+        {
+            editorError = result.ErrorMessage;
+            return;
+        }
+
+        CancelEditing();
+        pageMessage = result.SuccessMessage;
+        await LoadProductsAsync();
+    }
+
+    private static string FormatPrice(decimal price)
+        => $"{price.ToString("0.00", Bg)} EUR";
+
+    private sealed class EditablePriceRule
+    {
+        public string? PriceText { get; set; }
+        public int UnitsPerSale { get; set; }
+        public bool IsDefault { get; set; }
+    }
+}

--- a/MySalesTracker.Web/Components/Pages/PriceAdministration.razor.css
+++ b/MySalesTracker.Web/Components/Pages/PriceAdministration.razor.css
@@ -1,0 +1,249 @@
+.price-page-header {
+    display: flex;
+    align-items: center;
+    min-height: 2.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.price-page-header h2 {
+    margin: 0;
+}
+
+.brand-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.25rem;
+    width: 100%;
+    margin-bottom: 1rem;
+    padding: 0.25rem;
+    border: 1px solid #d9e2ec;
+    border-radius: 0.4rem;
+    background: #f3f6f9;
+}
+
+.brand-tab {
+    min-width: 0;
+    min-height: 2.5rem;
+    border: 0;
+    border-radius: 0.3rem;
+    color: #334155;
+    background: transparent;
+    font-size: 0.86rem;
+    font-weight: 600;
+}
+
+.brand-tab-active {
+    color: #fff;
+    background: #1769aa;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.18);
+}
+
+.product-price-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+}
+
+.product-price-card {
+    min-width: 0;
+    border: 1px solid #d9e2ec;
+    border-radius: 0.4rem;
+    background: #fff;
+    box-shadow: 0 0.15rem 0.45rem rgba(15, 23, 42, 0.06);
+    overflow: hidden;
+}
+
+.product-price-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.8rem;
+}
+
+.product-price-header h3 {
+    margin: 0 0 0.15rem;
+    font-size: 1.05rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.current-price-label,
+.free-price-label {
+    color: #64748b;
+    font-size: 0.78rem;
+}
+
+.free-price-label {
+    color: #7c3f00;
+    font-weight: 700;
+}
+
+.edit-price-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex: 0 0 auto;
+    min-height: 2.1rem;
+}
+
+.current-price-rules {
+    border-top: 1px solid #edf1f5;
+}
+
+.current-rule-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 4rem auto;
+    align-items: center;
+    gap: 0.5rem;
+    min-height: 2.6rem;
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid #edf1f5;
+}
+
+.current-rule-row:last-child {
+    border-bottom: 0;
+}
+
+.current-rule-row > :nth-child(2) {
+    color: #64748b;
+    text-align: right;
+}
+
+.default-price-label {
+    justify-self: end;
+    padding: 0.2rem 0.4rem;
+    border-radius: 999px;
+    color: #146c43;
+    background: #e7f6ee;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.free-price-state {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 0.8rem;
+    border-top: 1px solid #edf1f5;
+    color: #64748b;
+    font-size: 0.88rem;
+}
+
+.price-editor {
+    padding: 0.8rem;
+    border-top: 1px solid #dbe7f2;
+    background: #f8fafc;
+}
+
+.editor-column-labels,
+.editable-rule-row {
+    display: grid;
+    grid-template-columns: 2.25rem minmax(0, 1fr) 4.5rem 2.25rem;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.editor-column-labels {
+    margin-bottom: 0.25rem;
+    color: #64748b;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.editor-column-labels span:first-child {
+    text-align: center;
+}
+
+.editable-rule-row {
+    margin-bottom: 0.5rem;
+}
+
+.editable-rule-row input[type="radio"] {
+    justify-self: center;
+    width: 1.1rem;
+    height: 1.1rem;
+    accent-color: #16834f;
+}
+
+.editable-rule-row .form-control {
+    min-width: 0;
+    min-height: 2.35rem;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.9rem;
+}
+
+.units-input {
+    text-align: center;
+}
+
+.remove-rule-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.25rem;
+    height: 2.25rem;
+    border: 1px solid #e4a5a5;
+    border-radius: 0.35rem;
+    color: #a51d2d;
+    background: #fff;
+}
+
+.remove-rule-button:disabled {
+    opacity: 0.35;
+}
+
+.add-rule-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 0;
+    color: #1769aa;
+    background: transparent;
+    font-size: 0.83rem;
+    font-weight: 700;
+}
+
+.add-rule-button {
+    min-height: 2.2rem;
+    margin-top: 0.1rem;
+    padding: 0.25rem 0;
+}
+
+.editor-error {
+    margin-top: 0.5rem;
+    color: #a51d2d;
+    font-size: 0.82rem;
+}
+
+.editor-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.editor-actions .btn {
+    min-width: 5.5rem;
+    min-height: 2.2rem;
+}
+
+@media (min-width: 768px) {
+    .brand-tabs {
+        width: 28rem;
+    }
+
+    .product-price-list {
+        grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    }
+
+    .product-price-card {
+        align-self: start;
+    }
+}
+
+@media (min-width: 1200px) {
+    .product-price-list {
+        grid-template-columns: repeat(auto-fill, minmax(21rem, 24rem));
+    }
+}

--- a/MySalesTracker.Web/appsettings.Development.json
+++ b/MySalesTracker.Web/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DatabaseConnection": "Server=localhost,1435;Database=MySalesTracker;User ID=sa;Password=yourStrong(!)Password;Integrated Security=false;Encrypt=false;TrustServerCertificate=true;Max Pool Size=50;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/Tests/PriceRuleServiceTests.cs
+++ b/Tests/PriceRuleServiceTests.cs
@@ -1,0 +1,201 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MySalesTracker.Application.DTOs;
+using MySalesTracker.Application.Interfaces;
+using MySalesTracker.Application.Services;
+using MySalesTracker.Domain.Entities;
+using MySalesTracker.Domain.Enums;
+
+namespace MySalesTracker.Tests;
+
+public sealed class PriceRuleServiceTests
+{
+    [Fact]
+    public async Task UpdateProductPriceRulesAsync_ValidRules_CreatesOrderedReplacementSet()
+    {
+        var priceRuleRepository = new PriceRuleRepositoryFake();
+        var productRepository = new ProductRepositoryFake(CreateProduct(Brand.Totem));
+        var service = CreateService(priceRuleRepository, productRepository);
+        var request = new UpdateProductPriceRulesRequest(
+            1,
+            [new PriceRuleInput(40m, 1, false), new PriceRuleInput(75m, 2, true)]);
+
+        var result = await service.UpdateProductPriceRulesAsync(request);
+
+        Assert.True(result.Success);
+        Assert.Equal(1, priceRuleRepository.SavedProductId);
+        Assert.Collection(
+            priceRuleRepository.SavedRules,
+            first =>
+            {
+                Assert.Equal(40m, first.Price);
+                Assert.Equal(1, first.SortOrder);
+                Assert.False(first.IsDefault);
+            },
+            second =>
+            {
+                Assert.Equal(75m, second.Price);
+                Assert.Equal(2, second.SortOrder);
+                Assert.True(second.IsDefault);
+            });
+    }
+
+    [Fact]
+    public async Task UpdateProductPriceRulesAsync_DuplicatePrices_ReturnsFailure()
+    {
+        var priceRuleRepository = new PriceRuleRepositoryFake();
+        var service = CreateService(priceRuleRepository, new ProductRepositoryFake(CreateProduct(Brand.Totem)));
+        var request = new UpdateProductPriceRulesRequest(
+            1,
+            [new PriceRuleInput(40m, 1, true), new PriceRuleInput(40m, 2, false)]);
+
+        var result = await service.UpdateProductPriceRulesAsync(request);
+
+        Assert.False(result.Success);
+        Assert.Empty(priceRuleRepository.SavedRules);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task UpdateProductPriceRulesAsync_InvalidDefaultCount_ReturnsFailure(bool firstDefault, bool secondDefault)
+    {
+        var priceRuleRepository = new PriceRuleRepositoryFake();
+        var service = CreateService(priceRuleRepository, new ProductRepositoryFake(CreateProduct(Brand.Totem)));
+        var request = new UpdateProductPriceRulesRequest(
+            1,
+            [new PriceRuleInput(40m, 1, firstDefault), new PriceRuleInput(75m, 2, secondDefault)]);
+
+        var result = await service.UpdateProductPriceRulesAsync(request);
+
+        Assert.False(result.Success);
+        Assert.Empty(priceRuleRepository.SavedRules);
+    }
+
+    [Fact]
+    public async Task UpdateProductPriceRulesAsync_CeramicsProduct_ReturnsFailure()
+    {
+        var priceRuleRepository = new PriceRuleRepositoryFake();
+        var service = CreateService(priceRuleRepository, new ProductRepositoryFake(CreateProduct(Brand.Ceramics)));
+        var request = new UpdateProductPriceRulesRequest(
+            1,
+            [new PriceRuleInput(40m, 1, true)]);
+
+        var result = await service.UpdateProductPriceRulesAsync(request);
+
+        Assert.False(result.Success);
+        Assert.Empty(priceRuleRepository.SavedRules);
+    }
+
+    [Fact]
+    public async Task GetProductPricingAsync_ReturnsCurrentRulesInConfiguredOrder()
+    {
+        var product = CreateProduct(
+            Brand.Candles,
+            CreateRule(20m, false, 2),
+            CreateRule(10m, true, 1));
+        var service = CreateService(new PriceRuleRepositoryFake(), new ProductRepositoryFake(product));
+
+        var result = await service.GetProductPricingAsync();
+
+        var pricing = Assert.Single(result);
+        Assert.False(pricing.IsFreePrice);
+        Assert.Collection(
+            pricing.CurrentRules,
+            first =>
+            {
+                Assert.Equal(10m, first.Price);
+                Assert.True(first.IsDefault);
+            },
+            second => Assert.Equal(20m, second.Price));
+    }
+
+    [Fact]
+    public async Task GetUnitsForProductAsync_ConfiguredPrice_ReturnsUnits()
+    {
+        var repository = new PriceRuleRepositoryFake
+        {
+            RuleToReturn = CreateRule(30m, true, 1, unitsPerSale: 3)
+        };
+        var service = CreateService(repository, new ProductRepositoryFake(CreateProduct(Brand.Candles)));
+
+        var result = await service.GetUnitsForProductAsync(1, 30m);
+
+        Assert.Equal(3, result);
+    }
+
+    [Fact]
+    public async Task GetUnitsForProductAsync_MissingPrice_ReturnsNull()
+    {
+        var service = CreateService(
+            new PriceRuleRepositoryFake(),
+            new ProductRepositoryFake(CreateProduct(Brand.Candles)));
+
+        var result = await service.GetUnitsForProductAsync(1, 30m);
+
+        Assert.Null(result);
+    }
+
+    private static PriceRuleService CreateService(
+        IPriceRuleRepository priceRuleRepository,
+        IProductRepository productRepository)
+        => new(priceRuleRepository, productRepository, NullLogger<PriceRuleService>.Instance);
+
+    private static Product CreateProduct(Brand brand, params PriceRule[] rules)
+        => new()
+        {
+            ProductId = 1,
+            Name = "Test product",
+            Brand = brand,
+            PriceRules = rules.ToList()
+        };
+
+    private static PriceRule CreateRule(
+        decimal price,
+        bool isDefault,
+        int sortOrder,
+        int unitsPerSale = 1)
+        => new()
+        {
+            ProductId = 1,
+            Price = price,
+            Currency = Currency.EUR,
+            UnitsPerSale = unitsPerSale,
+            SortOrder = sortOrder,
+            IsDefault = isDefault
+        };
+
+    private sealed class ProductRepositoryFake(Product product) : IProductRepository
+    {
+        public Task<List<Product>> GetActiveProductsAsync(CancellationToken ct)
+            => Task.FromResult(new List<Product> { product });
+
+        public Task<List<Product>> GetActiveProductsWithPriceRulesAsync(CancellationToken ct)
+            => Task.FromResult(new List<Product> { product });
+
+        public Task<Product?> GetActiveProductWithPriceRulesAsync(int productId, CancellationToken ct)
+            => Task.FromResult<Product?>(product.ProductId == productId ? product : null);
+    }
+
+    private sealed class PriceRuleRepositoryFake : IPriceRuleRepository
+    {
+        public int? SavedProductId { get; private set; }
+        public List<PriceRule> SavedRules { get; private set; } = [];
+        public PriceRule? RuleToReturn { get; init; }
+
+        public Task<PriceRule?> GetRuleForProductAsync(int productId, decimal price, CancellationToken ct)
+            => Task.FromResult(RuleToReturn);
+
+        public Task<List<PriceRule>> GetAllPriceRulesAsync(CancellationToken ct)
+            => Task.FromResult(new List<PriceRule>());
+
+        public Task ReplacePriceRulesAsync(
+            int productId,
+            IReadOnlyCollection<PriceRule> priceRules,
+            CancellationToken ct)
+        {
+            SavedProductId = productId;
+            SavedRules = priceRules.ToList();
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add an authenticated price administration page grouped by brand.
- Allow users to manage current price rules and select one default price.
- Keep Ceramics as a free-price product.
- Remove hardcoded default prices.
- Update sale creation and editing to use the current price rules.

## Database changes

- Remove `Sale.PriceRuleId` and its foreign key.
- Remove `EffectiveFrom` and `EffectiveTo` from `PriceRules`.
- Preserve historical sale prices as snapshots in `Sale.Price`.
- Convert existing production rules dynamically without hardcoded values.
- Enforce one default price and unique prices per product.

## Validation

- Build succeeds with no errors.
- All 14 tests pass.
- Existing sale counts, totals, and checksums remain unchanged after migration.

**Migration note:** Create a production backup before deployment because removed price-rule history cannot be restored by rolling the migration back.