### PR TITLE
Optimize the forecast page

### DIFF
--- a/MySalesTracker.Web/Components/Pages/Weather.razor
+++ b/MySalesTracker.Web/Components/Pages/Weather.razor
@@ -4,54 +4,160 @@
 @inject WeatherState State
 @inject IWeatherService WeatherSvc
 
-<h2>шИ вали ли ⛈️🌪️👀 🥃🥴</h2>
+<PageTitle>Прогноза</PageTitle>
 
-<div class="mb-3 d-flex gap-2 flex-wrap align-items-center">
-    <input class="form-control" style="width: 18rem" placeholder="City (e.g. Sofia)" @bind="city" />
-    <select class="form-select" style="width: 8rem" @bind="displayDays">
-        @for (var d = 1; d <= MaxForecastDays; d++)
+<header class="weather-page-header">
+    <div>
+        <h2>Дали вали</h2>
+        @if (summary is not null)
         {
-       <option value="@d">@d @(d == 1 ? "day" : "days")</option>
+            <div class="weather-location">
+                <span class="bi bi-geo-alt" aria-hidden="true"></span>
+                <span>@summary.Name</span>
+            </div>
         }
-  </select>
-    <button class="btn btn-primary" @onclick="Load">Get forecast</button>
-</div>
+    </div>
+</header>
+
+<form class="forecast-controls" @onsubmit="Load" @onsubmit:preventDefault>
+    <label class="control-field city-control">
+        <span class="visually-hidden">Град</span>
+        <span class="bi bi-geo-alt control-icon" aria-hidden="true"></span>
+        <input class="form-control"
+               autocomplete="address-level2"
+               aria-label="Град"
+               placeholder="Град, напр. София"
+               @bind="city" />
+    </label>
+
+    <label class="control-field">
+        <span class="visually-hidden">Брой дни</span>
+        <select class="form-select" aria-label="Брой дни" @bind="displayDays">
+            @for (var d = 1; d <= MaxForecastDays; d++)
+            {
+                <option value="@d">@d @(d == 1 ? "ден" : "дни")</option>
+            }
+        </select>
+    </label>
+
+    <button type="submit"
+            class="btn btn-primary forecast-submit"
+            aria-label="Покажи прогноза"
+            title="Покажи прогноза"
+            disabled="@isLoading">
+        @if (isLoading)
+        {
+            <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+        }
+        else
+        {
+            <span class="bi bi-search" aria-hidden="true"></span>
+        }
+        <span class="forecast-button-label">@(isLoading ? "Зареждане" : "Покажи")</span>
+    </button>
+</form>
 
 @if (error is not null)
 {
-    <div class="alert alert-danger">@error</div>
+    <div class="alert alert-danger weather-alert" role="alert">@error</div>
 }
 
-@if (summary is not null)
+@if (summary is not null && SelectedDay is { } selectedDay)
 {
-    <div class="card p-3">
-        <div><b>Location:</b> @summary.Name (@summary.Lat.ToString("0.###", CultureInfo.InvariantCulture), @summary.Lon.ToString("0.###", CultureInfo.InvariantCulture))</div>
-        <div class="mt-2">
-            <b>Next @displayDays @(displayDays == 1 ? "day" : "days"):</b>
-             @foreach (var day in summary.Days)
-             {
-                 <div class="day-block mt-3">
-                     <div class="day-title">@day.DayLabel</div>
-                     <div class="hour-grid mt-2">
-                        @foreach (var hour in day.Hours)
-                        {
-                            var bg = WeatherCalculations.GetRainBackgroundColor(hour.Mm);
-                            var edge = WeatherCalculations.GetRainBorderColor(hour.Mm);
-                            var textColor = WeatherCalculations.GetRainTextColor(hour.Mm);
-                            <div class="hour-card" style="background-color: @bg; border-color:@edge; color:@textColor">
-                                 <div class="hour-time">@hour.TimeLabel</div>
-                                 <div class="hour-values">
-                                     <span class="me-2">@hour.Temp.ToString("0.#", CultureInfo.InvariantCulture)&deg;C</span>
-                                     <span>Wind @hour.Wind.ToString("0.#", CultureInfo.InvariantCulture) km/h</span>
-                                 </div>
-                                 <div class="hour-rain">Chance @hour.Prob% (@hour.Mm.ToString("0.0", CultureInfo.InvariantCulture) mm)</div>
-                             </div>
-                         }
-                     </div>
-                 </div>
-               }
+    <section class="forecast-panel" aria-labelledby="selected-day-title">
+        <div class="day-tabs" role="tablist" aria-label="Дни от прогнозата">
+            @for (var index = 0; index < summary.Days.Count; index++)
+            {
+                var tabIndex = index;
+                var day = summary.Days[index];
+                <button type="button"
+                        role="tab"
+                        aria-selected="@(selectedDayIndex == index)"
+                        class="day-tab @(selectedDayIndex == index ? "day-tab-active" : null)"
+                        @onclick="() => SelectDay(tabIndex)">
+                    <span class="day-tab-name">@GetDayTabName(day.Date, index)</span>
+                    <span class="day-tab-date">@FormatDate(day.Date)</span>
+                </button>
+            }
         </div>
-    </div>
+
+        <div class="day-overview">
+            <h3 id="selected-day-title">@FormatDayHeading(selectedDay.Date)</h3>
+
+            <div class="weather-metrics">
+                <div class="weather-metric temperature-metric">
+                    <span class="bi bi-thermometer-half metric-icon" aria-hidden="true"></span>
+                    <div>
+                        <span class="metric-label">Температура</span>
+                        <strong>@FormatTemperature(selectedDay.MinTemperature) / @FormatTemperature(selectedDay.MaxTemperature)</strong>
+                    </div>
+                </div>
+
+                <div class="weather-metric probability-metric">
+                    <span class="bi bi-umbrella metric-icon" aria-hidden="true"></span>
+                    <div>
+                        <span class="metric-label">Дъжд</span>
+                        <strong>@selectedDay.MaxRainProbability%</strong>
+                    </div>
+                </div>
+
+                <div class="weather-metric precipitation-metric">
+                    <span class="bi bi-droplet metric-icon" aria-hidden="true"></span>
+                    <div>
+                        <span class="metric-label">Валежи</span>
+                        <strong>@FormatNumber(selectedDay.TotalPrecipitation) mm</strong>
+                    </div>
+                </div>
+
+                <div class="weather-metric wind-metric">
+                    <span class="bi bi-wind metric-icon" aria-hidden="true"></span>
+                    <div>
+                        <span class="metric-label">Вятър</span>
+                        <strong>@FormatNumber(selectedDay.MaxWindSpeed) km/h</strong>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="hourly-section">
+            <div class="hourly-heading">
+                <h4>По часове</h4>
+                <span class="bi bi-arrow-left-right" aria-hidden="true"></span>
+            </div>
+
+            <div class="hourly-scroller"
+                 tabindex="0"
+                 aria-label="Почасова прогноза за @FormatDayHeading(selectedDay.Date)">
+                <div class="hourly-track">
+                    @foreach (var hour in selectedDay.Hours)
+                    {
+                        var rainAccent = WeatherCalculations.GetRainBorderColor(hour.Mm);
+                        var rainProbability = Math.Clamp(hour.Prob, 0, 100);
+
+                        <article class="hour-item">
+                            <time class="hour-time"
+                                  datetime="@hour.Time.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture)">
+                                @hour.Time.ToString("HH:mm", CultureInfo.InvariantCulture)
+                            </time>
+                            <strong class="hour-temperature">@FormatTemperature(hour.Temp)</strong>
+                            <div class="hour-rain">
+                                <span class="bi bi-droplet-fill" aria-hidden="true"></span>
+                                <span>@rainProbability%</span>
+                            </div>
+                            <span class="hour-precipitation">@FormatNumber(hour.Mm) mm</span>
+                            <div class="hour-wind">
+                                <span class="bi bi-wind" aria-hidden="true"></span>
+                                <span>@FormatNumber(hour.Wind)</span>
+                            </div>
+                            <div class="rain-probability-bar" aria-hidden="true">
+                                <span style="width: @(rainProbability)%; background-color: @rainAccent"></span>
+                            </div>
+                        </article>
+                    }
+                </div>
+            </div>
+        </div>
+    </section>
 }
 
 @code {
@@ -61,12 +167,28 @@
     string city = "Sofia";
     string? error;
     int displayDays = 3;
+    int selectedDayIndex;
+    bool isLoading;
 
-    record HourEntry(string TimeLabel, double Temp, double Wind, int Prob, double Mm);
-    record DayForecast(string DayLabel, List<HourEntry> Hours);
-    record Summary(string Name, double Lat, double Lon, List<DayForecast> Days);
+    sealed record HourEntry(DateTime Time, double Temp, double Wind, int Prob, double Mm);
+
+    sealed record DayForecast(DateOnly Date, List<HourEntry> Hours)
+    {
+        public double MinTemperature => Hours.Count == 0 ? 0 : Hours.Min(hour => hour.Temp);
+        public double MaxTemperature => Hours.Count == 0 ? 0 : Hours.Max(hour => hour.Temp);
+        public int MaxRainProbability => Hours.Count == 0 ? 0 : Hours.Max(hour => hour.Prob);
+        public double TotalPrecipitation => Hours.Sum(hour => hour.Mm);
+        public double MaxWindSpeed => Hours.Count == 0 ? 0 : Hours.Max(hour => hour.Wind);
+    }
+
+    sealed record Summary(string Name, double Lat, double Lon, List<DayForecast> Days);
 
     Summary? summary;
+
+    DayForecast? SelectedDay
+        => summary is null || selectedDayIndex < 0 || selectedDayIndex >= summary.Days.Count
+            ? null
+            : summary.Days[selectedDayIndex];
 
     protected override void OnInitialized()
     {
@@ -81,8 +203,13 @@
                 State.LastSummary.Lon,
                 State.LastSummary.Days
                     .Select(day => new DayForecast(
-                        day.DayLabel,   
-                        day.Hours.Select(hour => new HourEntry(hour.TimeLabel, hour.Temp, hour.Wind, hour.Prob, hour.Mm)).ToList()))
+                        day.Date,
+                        day.Hours.Select(hour => new HourEntry(
+                            hour.Time,
+                            hour.Temp,
+                            hour.Wind,
+                            hour.Prob,
+                            hour.Mm)).ToList()))
                     .ToList());
         }
     }
@@ -90,8 +217,6 @@
     async Task Load()
     {
         error = null;
-        summary = null;
-
         city = city.Trim();
 
         if (string.IsNullOrWhiteSpace(city))
@@ -104,69 +229,121 @@
         State.City = city;
         State.DisplayDays = displayDays;
 
-        var geo = await WeatherSvc.FetchGeocode(city);
-
-        if (geo is null)
+        isLoading = true;
+        try
         {
-            error = "Градът не е намерен.";
-            return;
+            var geo = await WeatherSvc.FetchGeocode(city);
+
+            if (geo is null)
+            {
+                error = "Градът не е намерен.";
+                return;
+            }
+
+            var (lat, lon, name) = geo.Value;
+            var forecast = await WeatherSvc.GetForecast(lat, lon, displayDays);
+
+            if (forecast?.Hours is null || forecast.Hours.Count == 0)
+            {
+                error = "Няма данни за метеорологичната прогноза.";
+                return;
+            }
+
+            var maxHours = Math.Min(displayDays * HoursPerDay, forecast.Hours.Count);
+            var parsedHours = new List<(DateTime Date, HourEntry Hour)>();
+
+            for (var i = 0; i < maxHours; i++)
+            {
+                var hour = forecast.Hours[i];
+                parsedHours.Add((
+                    hour.Time.Date,
+                    new HourEntry(
+                        hour.Time,
+                        hour.Temperature,
+                        hour.WindSpeed,
+                        hour.PrecipitationProbability,
+                        hour.Precipitation)));
+            }
+
+            if (parsedHours.Count == 0)
+            {
+                error = "Няма налични метеорологични данни.";
+                return;
+            }
+
+            var daySummaries = parsedHours
+                .GroupBy(entry => entry.Date)
+                .OrderBy(group => group.Key)
+                .Take(displayDays)
+                .Select(group => new DayForecast(
+                    DateOnly.FromDateTime(group.Key),
+                    group.Select(entry => entry.Hour).ToList()))
+                .ToList();
+
+            if (daySummaries.Count == 0)
+            {
+                error = "Няма налични метеорологични данни.";
+                return;
+            }
+
+            summary = new Summary(name ?? city, lat, lon, daySummaries);
+            selectedDayIndex = 0;
+
+            State.Store(
+                new WeatherState.Summary(
+                    summary.Name,
+                    summary.Lat,
+                    summary.Lon,
+                    daySummaries
+                        .Select(day => new WeatherState.DaySummary(
+                            day.Date,
+                            day.Hours.Select(hour => new WeatherState.HourEntry(
+                                hour.Time,
+                                hour.Temp,
+                                hour.Wind,
+                                hour.Prob,
+                                hour.Mm)).ToList()))
+                        .ToList()));
         }
-
-        var (lat, lon, name) = geo.Value;
-        var forecast = await WeatherSvc.GetForecast(lat, lon, displayDays);
-
-        if (forecast?.Hours is null || forecast.Hours.Count == 0)
+        catch
         {
-            error = "Няма данни за метеорологичната прогноза.";
-            return;
+            error = "Прогнозата не можа да бъде заредена.";
         }
-
-        var maxHours = Math.Min(displayDays * HoursPerDay, forecast.Hours.Count);
-        var parsedHours = new List<(DateTime Date, HourEntry Hour)>();
-
-        for (int i = 0; i < maxHours; i++)
+        finally
         {
-            var hour = forecast.Hours[i];
-            var timeLabel = hour.Time.ToString("HH:mm", CultureInfo.InvariantCulture);
-            parsedHours.Add((hour.Time.Date, new HourEntry(timeLabel, hour.Temperature, hour.WindSpeed, hour.PrecipitationProbability, hour.Precipitation)));
+            isLoading = false;
         }
-
-        if (parsedHours.Count == 0)
-        {
-            error = "Няма налични метеорологични данни.";
-            return;
-        }
-
-        var daySummaries = parsedHours
-            .GroupBy(x => x.Date)
-            .OrderBy(g => g.Key)
-            .Take(displayDays)
-            .Select(group =>
-                {
-                    var dayLabel = group.Key.ToString("dddd, dd MMMM", CultureInfo.InvariantCulture);
-                    return new DayForecast(dayLabel, group.Select(x => x.Hour).ToList());
-                })
-            .ToList();
-
-        if (daySummaries.Count == 0)    
-        {
-            error = "Няма налични метеорологични данни.";
-            return;
-        }
-
-        summary = new Summary(name ?? city, lat, lon, daySummaries);
-
-        State.Store(
-            new WeatherState.Summary(
-                summary.Name,
-                summary.Lat,
-                summary.Lon,
-                daySummaries
-                    .Select(day => new WeatherState.DaySummary(
-                            day.DayLabel,
-                            day.Hours.Select(hour => new WeatherState.HourEntry(hour.TimeLabel, hour.Temp, hour.Wind, hour.Prob, hour.Mm)).ToList()))
-                    .ToList()
-            )
-        );
     }
+
+    void SelectDay(int index)
+    {
+        if (summary is null || index < 0 || index >= summary.Days.Count)
+        {
+            return;
+        }
+
+        selectedDayIndex = index;
+    }
+
+    static string GetDayTabName(DateOnly date, int index)
+        => index switch
+        {
+            0 => "Днес",
+            1 => "Утре",
+            _ => date.ToDateTime(TimeOnly.MinValue).ToString("ddd", Bg).TrimEnd('.')
+        };
+
+    static string FormatDate(DateOnly date)
+        => date.ToString("dd.MM", Bg);
+
+    static string FormatDayHeading(DateOnly date)
+        => date.ToDateTime(TimeOnly.MinValue).ToString("dddd, d MMMM", Bg);
+
+    static string FormatTemperature(double value)
+        => $"{value.ToString("0.#", Bg)}°";
+
+    static string FormatNumber(double value)
+        => value.ToString("0.#", Bg);
+
+    static readonly CultureInfo Bg = CultureInfo.GetCultureInfo("bg-BG");
 }

--- a/MySalesTracker.Web/Components/Pages/Weather.razor
+++ b/MySalesTracker.Web/Components/Pages/Weather.razor
@@ -75,7 +75,7 @@
                         aria-selected="@(selectedDayIndex == index)"
                         class="day-tab @(selectedDayIndex == index ? "day-tab-active" : null)"
                         @onclick="() => SelectDay(tabIndex)">
-                    <span class="day-tab-name">@GetDayTabName(day.Date, index)</span>
+                    <span class="day-tab-name">@GetDayTabName(day.Date)</span>
                     <span class="day-tab-date">@FormatDate(day.Date)</span>
                 </button>
             }
@@ -325,13 +325,8 @@
         selectedDayIndex = index;
     }
 
-    static string GetDayTabName(DateOnly date, int index)
-        => index switch
-        {
-            0 => "Днес",
-            1 => "Утре",
-            _ => date.ToDateTime(TimeOnly.MinValue).ToString("ddd", Bg).TrimEnd('.')
-        };
+    static string GetDayTabName(DateOnly date)
+        => date.ToDateTime(TimeOnly.MinValue).ToString("ddd", Bg).TrimEnd('.');
 
     static string FormatDate(DateOnly date)
         => date.ToString("dd.MM", Bg);

--- a/MySalesTracker.Web/Components/Pages/Weather.razor.css
+++ b/MySalesTracker.Web/Components/Pages/Weather.razor.css
@@ -259,7 +259,6 @@
     scroll-snap-type: inline proximity;
     scrollbar-width: thin;
     overscroll-behavior-inline: contain;
-    touch-action: pan-x;
     -webkit-overflow-scrolling: touch;
 }
 

--- a/MySalesTracker.Web/Components/Pages/Weather.razor.css
+++ b/MySalesTracker.Web/Components/Pages/Weather.razor.css
@@ -1,35 +1,396 @@
-.day-block {
-  border-top: 1px solid rgba(0, 0, 0, 0.08);
-  padding-top: 12px;
+.weather-page-header {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    min-height: 2.75rem;
+    margin-bottom: 0.75rem;
 }
-.day-block:first-of-type {
-  border-top: none;
-  padding-top: 0;
+
+.weather-page-header h2 {
+    margin: 0;
+    font-size: 1.75rem;
+    letter-spacing: 0;
 }
-.day-title {
-  font-weight: 600;
-  font-size: 1.05rem;
+
+.weather-location {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-top: 0.2rem;
+    color: #52606d;
+    font-size: 0.85rem;
 }
-.hour-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
+
+.forecast-controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(5.75rem, 6.75rem) 2.75rem;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 44rem;
+    margin-bottom: 1rem;
 }
-.hour-card {
-  border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 10px 12px;
-  /* Visual enhancement with backdrop saturation; include WebKit prefix for Safari */
-  -webkit-backdrop-filter: saturate(120%);
-  backdrop-filter: saturate(120%);
+
+.control-field {
+    min-width: 0;
+    margin: 0;
 }
+
+.city-control {
+    position: relative;
+}
+
+.control-icon {
+    position: absolute;
+    top: 50%;
+    left: 0.8rem;
+    z-index: 1;
+    color: #66788a;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.city-control .form-control {
+    padding-left: 2.25rem;
+}
+
+.forecast-controls .form-control,
+.forecast-controls .form-select,
+.forecast-submit {
+    min-height: 2.75rem;
+}
+
+.forecast-controls .form-control,
+.forecast-controls .form-select {
+    width: 100%;
+    min-width: 0;
+}
+
+.forecast-submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    width: 100%;
+    padding-inline: 0.65rem;
+}
+
+.forecast-button-label {
+    display: none;
+}
+
+.weather-alert {
+    width: 100%;
+    max-width: 44rem;
+}
+
+.forecast-panel {
+    width: 100%;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid #d8e0e8;
+    border-radius: 0.5rem;
+    background: #fff;
+    box-shadow: 0 0.15rem 0.45rem rgba(15, 23, 42, 0.06);
+}
+
+.day-tabs {
+    display: flex;
+    gap: 0.25rem;
+    overflow-x: auto;
+    padding: 0.35rem;
+    border-bottom: 1px solid #dfe6ed;
+    background: #f3f6f8;
+    scrollbar-width: thin;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
+.day-tab {
+    display: flex;
+    flex: 0 0 clamp(5.25rem, 25vw, 6.75rem);
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    min-height: 3.35rem;
+    padding: 0.35rem 0.5rem;
+    border: 0;
+    border-radius: 0.35rem;
+    color: #52606d;
+    background: transparent;
+}
+
+.day-tab:hover {
+    background: #e7edf2;
+}
+
+.day-tab:focus-visible {
+    outline: 0.15rem solid #1769aa;
+    outline-offset: -0.15rem;
+}
+
+.day-tab-active {
+    color: #0f4f7d;
+    background: #fff;
+    box-shadow: 0 0.08rem 0.25rem rgba(15, 23, 42, 0.18);
+}
+
+.day-tab-active:hover {
+    background: #fff;
+}
+
+.day-tab-name {
+    max-width: 100%;
+    overflow: hidden;
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    text-transform: capitalize;
+    white-space: nowrap;
+}
+
+.day-tab-date {
+    color: #64748b;
+    font-size: 0.72rem;
+}
+
+.day-overview {
+    padding: clamp(0.75rem, 3vw, 1rem);
+}
+
+.day-overview h3 {
+    margin: 0 0 0.7rem;
+    font-size: 1.05rem;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: capitalize;
+}
+
+.weather-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
+}
+
+.weather-metric {
+    display: grid;
+    grid-template-columns: 1.8rem minmax(0, 1fr);
+    align-items: center;
+    gap: 0.45rem;
+    min-width: 0;
+    min-height: 3.6rem;
+    padding: 0.55rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.4rem;
+    background: #f8fafc;
+}
+
+.metric-icon {
+    justify-self: center;
+    font-size: 1.15rem;
+}
+
+.temperature-metric .metric-icon {
+    color: #b42318;
+}
+
+.probability-metric .metric-icon {
+    color: #1769aa;
+}
+
+.precipitation-metric .metric-icon {
+    color: #087f8c;
+}
+
+.wind-metric .metric-icon {
+    color: #587246;
+}
+
+.weather-metric > div {
+    min-width: 0;
+}
+
+.metric-label {
+    display: block;
+    overflow: hidden;
+    color: #64748b;
+    font-size: 0.68rem;
+    line-height: 1.2;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.weather-metric strong {
+    display: block;
+    overflow-wrap: anywhere;
+    font-size: 0.84rem;
+    line-height: 1.25;
+}
+
+.hourly-section {
+    min-width: 0;
+    border-top: 1px solid #dfe6ed;
+}
+
+.hourly-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 2.5rem;
+    padding: 0.55rem 0.8rem;
+}
+
+.hourly-heading h4 {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0;
+}
+
+.hourly-heading > span {
+    color: #64748b;
+}
+
+.hourly-scroller {
+    width: 100%;
+    overflow-x: auto;
+    border-top: 1px solid #edf1f5;
+    scroll-snap-type: inline proximity;
+    scrollbar-width: thin;
+    overscroll-behavior-inline: contain;
+    touch-action: pan-x;
+    -webkit-overflow-scrolling: touch;
+}
+
+.hourly-scroller:focus-visible {
+    outline: 0.15rem solid #1769aa;
+    outline-offset: -0.15rem;
+}
+
+.hourly-track {
+    display: grid;
+    grid-auto-columns: clamp(4.75rem, 21vw, 5.75rem);
+    grid-auto-flow: column;
+    width: max-content;
+    min-width: 100%;
+}
+
+.hour-item {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    min-width: 0;
+    min-height: 8.9rem;
+    padding: 0.6rem 0.35rem 0.75rem;
+    border-right: 1px solid #edf1f5;
+    background: #fff;
+    text-align: center;
+    scroll-snap-align: start;
+}
+
+.hour-item:last-child {
+    border-right: 0;
+}
+
 .hour-time {
-  font-weight: 600;
+    color: #52606d;
+    font-size: 0.72rem;
+    font-weight: 700;
 }
-.hour-values {
-  font-size: 0.9rem;
+
+.hour-temperature {
+    margin-top: 0.25rem;
+    color: #172b3a;
+    font-size: 1.05rem;
+    line-height: 1.2;
 }
+
+.hour-rain,
+.hour-wind {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.2rem;
+}
+
 .hour-rain {
-  font-size: 1.05rem;
-  font-weight: 600;
+    margin-top: 0.45rem;
+    color: #1769aa;
+    font-size: 0.76rem;
+    font-weight: 700;
+}
+
+.hour-precipitation {
+    min-height: 1rem;
+    margin-top: 0.05rem;
+    color: #64748b;
+    font-size: 0.66rem;
+}
+
+.hour-wind {
+    margin-top: 0.35rem;
+    color: #52606d;
+    font-size: 0.66rem;
+}
+
+.rain-probability-bar {
+    position: absolute;
+    right: 0.45rem;
+    bottom: 0.35rem;
+    left: 0.45rem;
+    height: 0.22rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: #e7edf2;
+}
+
+.rain-probability-bar span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+}
+
+@media (min-width: 36rem) {
+    .forecast-controls {
+        grid-template-columns: minmax(14rem, 1fr) 7.5rem auto;
+    }
+
+    .forecast-submit {
+        width: auto;
+        min-width: 7.5rem;
+        padding-inline: 1rem;
+    }
+
+    .forecast-button-label {
+        display: inline;
+    }
+
+    .weather-metrics {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .hourly-track {
+        grid-auto-columns: clamp(5rem, 13vw, 6rem);
+    }
+}
+
+@media (min-width: 64rem) {
+    .day-tab {
+        flex-basis: 6.75rem;
+    }
+
+    .day-overview {
+        padding: 1rem 1.25rem;
+    }
+
+    .hourly-heading {
+        padding-inline: 1.25rem;
+    }
+
+    .hourly-track {
+        grid-auto-columns: 6rem;
+    }
 }

--- a/MySalesTracker.Web/State/WeatherState.cs
+++ b/MySalesTracker.Web/State/WeatherState.cs
@@ -5,8 +5,8 @@ public sealed class WeatherState
     public string City { get; set; } = "Sofia";
     public int DisplayDays { get; set; } = 3;
 
-    public record HourEntry(string TimeLabel, double Temp, double Wind, int Prob, double Mm);
-    public record DaySummary(string DayLabel, List<HourEntry> Hours);
+    public record HourEntry(DateTime Time, double Temp, double Wind, int Prob, double Mm);
+    public record DaySummary(DateOnly Date, List<HourEntry> Hours);
     public record Summary(string Name, double Lat, double Lon, List<DaySummary> Days);
 
     public Summary? LastSummary { get; private set; }


### PR DESCRIPTION
# Optimize the forecast page

## Summary

Improve the forecast page with a mobile-first, responsive layout designed for phone usage.

## Changes

- Replace stacked hourly cards with a compact horizontal timeline.
- Display one selected day at a time using scrollable day tabs.
- Add daily temperature, rain, precipitation, and wind summaries.
- Make controls and forecast elements responsive across mobile and desktop resolutions.
- Add touch-friendly horizontal scrolling with scroll snapping.
- Localize the forecast controls and labels in Bulgarian.
- Preserve forecast state when navigating between pages.
- Add loading and error states.

## Validation

- Web project builds successfully.
- All 14 automated tests pass.
- No database or weather API changes are required.